### PR TITLE
pointing coreir-apps to master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 [submodule "coreir-apps"]
     path = coreir-apps
     url = https://github.com/rdaly525/coreir
-    branch = dev
+    branch = master 
 [submodule "tapeout"]
     path = tapeout
     url = https://github.com/stanfordaha/garnet


### PR DESCRIPTION
After this passes, we can get rid of "coreir-apps" altogether