### PR TITLE
Revert glb_test back

### DIFF
--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -119,10 +119,7 @@ def dispatch(args, extra_args=None):
             "handcrafted/pond_accum",
             "handcrafted/pond_and_mem"
         ]
-        glb_tests = []
-        # glb_tests = [
-        #    "apps/unsharp"
-        # ]
+        glb_tests = [ ]
     elif args.config == "daily":
         width, height = 16, 16
         tests = [
@@ -146,12 +143,11 @@ def dispatch(args, extra_args=None):
             "handcrafted/resnet_pond",
             "handcrafted/pond_and_mem",
         ]
-        glb_tests = []
-        # glb_tests = [
-        #     "apps/gaussian",
-        #     "apps/unsharp",
-        #     "apps/resnet_layer_gen"
-        # ]
+        glb_tests = [
+            "apps/gaussian",
+            "apps/unsharp",
+            "apps/resnet_layer_gen"
+        ]
     elif args.config == "full":
         width, height = 32, 16
         tests = [
@@ -181,13 +177,12 @@ def dispatch(args, extra_args=None):
             "handcrafted/resnet_pond",
             "handcrafted/pond_and_mem"
         ]
-        glb_tests = []
-        # glb_tests = [
-        #     "apps/gaussian",
-        #     "apps/unsharp",
-        #     "apps/resnet_layer_gen",
-        #     "apps/camera_pipeline"
-        # ]
+        glb_tests = [
+            "apps/gaussian",
+            "apps/unsharp",
+            "apps/resnet_layer_gen",
+            "apps/camera_pipeline"
+        ]
 
     else:
         raise NotImplementedError(f"Unknown test config: {config}")


### PR DESCRIPTION
I reverted `glb regression` tests back.
For `args.config == pr` case, `apps/unsharp` cannot be mapped onto 6x6, so i just removed it.