### PR TITLE
Aha report util

### DIFF
--- a/aha/util/glb.py
+++ b/aha/util/glb.py
@@ -16,7 +16,7 @@ def add_subparser(subparser):
 
 def subprocess_call_log(cmd, cwd, env, log, log_file_path):
     if log:
-        print("[log] Command  : {}".format(cmd))
+        print("[log] Command  : {}".format(" ".join(cmd)))
         print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
         with open(log_file_path, "a") as flog:
             subprocess.check_call(

--- a/aha/util/glb.py
+++ b/aha/util/glb.py
@@ -16,22 +16,23 @@ def add_subparser(subparser):
 
 def subprocess_call_log(cmd, cwd, env, log, log_file_path):
     if log:
-        proc = subprocess.Popen(
-            cmd,
-            cwd=cwd,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-        subprocess.check_call(["tee", log_file_path, "-a"], stdin=proc.stdout)
-        proc.wait()
+        print("[log] Command  : {}".format(cmd))
+        print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
+        with open(log_file_path, "a") as flog:
+            subprocess.check_call(
+                cmd,
+                cwd=cwd,
+                env=env,
+                stdout=flog,
+                stderr=flog
+            )
+        print("done")
     else:
         subprocess.check_call(
             cmd,
             cwd=cwd,
             env=env
         )
-
 
 
 def dispatch(args, extra_args=None):

--- a/aha/util/halide.py
+++ b/aha/util/halide.py
@@ -15,15 +15,17 @@ def add_subparser(subparser):
 
 def subprocess_call_log(cmd, cwd, env, log, log_file_path):
     if log:
-        proc = subprocess.Popen(
-            cmd,
-            cwd=cwd,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-        subprocess.check_call(["tee", log_file_path, "-a"], stdin=proc.stdout)
-        proc.wait()
+        print("[log] Command  : {}".format(cmd))
+        print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
+        with open(log_file_path, "a") as flog:
+            subprocess.check_call(
+                cmd,
+                cwd=cwd,
+                env=env,
+                stdout=flog,
+                stderr=flog
+            )
+        print("done")
     else:
         subprocess.check_call(
             cmd,

--- a/aha/util/halide.py
+++ b/aha/util/halide.py
@@ -15,7 +15,7 @@ def add_subparser(subparser):
 
 def subprocess_call_log(cmd, cwd, env, log, log_file_path):
     if log:
-        print("[log] Command  : {}".format(cmd))
+        print("[log] Command  : {}".format(" ".join(cmd)))
         print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
         with open(log_file_path, "a") as flog:
             subprocess.check_call(
@@ -58,7 +58,7 @@ def dispatch(args, extra_args=None):
     if "handcrafted" in str(args.app):
         # Generate pgm Images
         subprocess_call_log (
-            cmd=["make", "-C", app_dir, "bin/input.raw", "bin/output_cpu.raw"],
+            cmd=["make", "-C", str(app_dir), "bin/input.raw", "bin/output_cpu.raw"],
             cwd=args.aha_dir / "Halide-to-Hardware",
             env=env,
             log=args.log,
@@ -72,7 +72,7 @@ def dispatch(args, extra_args=None):
     else:
         # Raw Images
         subprocess_call_log (
-            cmd=["make", "-C", app_dir, "compare", "bin/input_cgra.pgm", "bin/output_cgra_comparison.pgm"],
+            cmd=["make", "-C", str(app_dir), "compare", "bin/input_cgra.pgm", "bin/output_cgra_comparison.pgm"],
             cwd=args.aha_dir / "Halide-to-Hardware",
             env=env,
             log=args.log,
@@ -88,7 +88,7 @@ def dispatch(args, extra_args=None):
 
     if run_sim:
         subprocess_call_log (
-            cmd=["make", "-C", app_dir, "test-mem"],
+            cmd=["make", "-C", str(app_dir), "test-mem"],
             cwd=args.aha_dir / "Halide-to-Hardware",
             env=env,
             log=args.log,
@@ -96,7 +96,7 @@ def dispatch(args, extra_args=None):
         )
     else:
         subprocess_call_log (
-            cmd=["make", "-C", app_dir, "map"],
+            cmd=["make", "-C", str(app_dir), "map"],
             cwd=args.aha_dir / "Halide-to-Hardware",
             env=env,
             log=args.log,

--- a/aha/util/map.py
+++ b/aha/util/map.py
@@ -15,14 +15,16 @@ def add_subparser(subparser):
 
 def subprocess_call_log(cmd, cwd, log, log_file_path):
     if log:
-        proc = subprocess.Popen(
-            cmd,
-            cwd=cwd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-        subprocess.check_call(["tee", log_file_path, "-a"], stdin=proc.stdout)
-        proc.wait()
+        print("[log] Command  : {}".format(cmd))
+        print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
+        with open(log_file_path, "a") as flog:
+            subprocess.check_call(
+                cmd,
+                cwd=cwd,
+                stdout=flog,
+                stderr=flog
+            )
+        print("done")
     else:
         subprocess.check_call(
             cmd,

--- a/aha/util/map.py
+++ b/aha/util/map.py
@@ -15,7 +15,7 @@ def add_subparser(subparser):
 
 def subprocess_call_log(cmd, cwd, log, log_file_path):
     if log:
-        print("[log] Command  : {}".format(cmd))
+        print("[log] Command  : {}".format(" ".join(cmd)))
         print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
         with open(log_file_path, "a") as flog:
             subprocess.check_call(
@@ -54,13 +54,13 @@ def dispatch(args, extra_args=None):
         "--no-pd",
         "--interconnect-only",
         "--input-app",
-        app_dir / "bin/design_top.json",
+        str(app_dir / "bin/design_top.json"),
         "--input-file",
-        app_dir / f"bin/input{ext}",
+        str(app_dir / f"bin/input{ext}"),
         "--output-file",
-        app_dir / f"bin/{args.app.name}.bs",
+        str(app_dir / f"bin/{args.app.name}.bs"),
         "--gold-file",
-        app_dir / f"bin/gold{ext}",
+        str(app_dir / f"bin/gold{ext}"),
     ]
 
     log_path = app_dir / Path("log")
@@ -82,7 +82,7 @@ def dispatch(args, extra_args=None):
             # get the full path of the app
             arg_path = f"{args.aha_dir}/Halide-to-Hardware/apps/hardware_benchmarks/{args.app}"
             subprocess_call_log (
-                [sys.executable,
+                cmd=[sys.executable,
                  f"{args.aha_dir}/Halide-to-Hardware/apps/hardware_benchmarks/hw_support/parse_design_meta.py",
                  "bin/design_meta_halide.json",
                  "--top", "bin/design_top.json",

--- a/aha/util/report.py
+++ b/aha/util/report.py
@@ -7,7 +7,7 @@ import re
 
 pattern_usage = re.compile(r"^(PE|MEM|Pond|IO|Reg)s:\s(\d+)")
 pattern_critical_path = re.compile(r"^\s*Critical Path: (\d+.?\d*)")
-pattern_cycle = re.compile(r"^\$finish at simulation time\s*(\d+).?\d* ns")
+pattern_cycle = re.compile(r"^\[.+\]\sIt\stakes\s(\d+\.\d*)\sns\stotal\stime\sto\srun\skernel")
 
 def add_subparser(subparser):
     parser = subparser.add_parser(Path(__file__).stem, add_help=False)

--- a/aha/util/report.py
+++ b/aha/util/report.py
@@ -8,7 +8,6 @@ import pandas as pd
 from datetime import datetime
 
 
-
 def add_subparser(subparser):
     parser = subparser.add_parser(Path(__file__).stem, add_help=False)
     parser.add_argument("app")
@@ -198,4 +197,3 @@ def dispatch(args, extra_args=None):
     print_report_items(report_items)
     if args.dump_report:
         dump_to_csv(report_items, csv_path=args.dump_report_location)
-

--- a/aha/util/report.py
+++ b/aha/util/report.py
@@ -9,6 +9,7 @@ pattern_usage = re.compile(r"^(PE|MEM|Pond|IO|Reg)s:\s(\d+)")
 pattern_critical_path = re.compile(r"^\s*Critical Path: (\d+.?\d*)")
 pattern_cycle = re.compile(r"^\[.+\]\sIt\stakes\s(\d+\.\d*)\sns\stotal\stime\sto\srun\skernel")
 
+
 def add_subparser(subparser):
     parser = subparser.add_parser(Path(__file__).stem, add_help=False)
     parser.add_argument("app")
@@ -94,7 +95,6 @@ def get_array_dimension():
         subprocess.check_call(cmd, stdout=f_temp)
     # parse the grep results
     pattern = re.compile(r"^Tile_(PE|MemCore)\sTile_X(\w+)_Y(\w+)\s\(")
-    i=0
     with open(temp_file, "r") as f_temp:
         line = f_temp.readline()
         while line:
@@ -107,7 +107,8 @@ def get_array_dimension():
                     results["Total_PE"] += 1
                 elif tile == "MemCore":
                     results["Total_MemCore"] += 1
-                results["Array_Width"] = max(x_dim+1, results["Array_Width"])
+                results["Array_Width"] = max(x_dim + 1, results["Array_Width"])
+                # on vertical direction, we have IO tile at top, so don't need +1
                 results["Array_Height"] = max(y_dim, results["Array_Height"])
             line = f_temp.readline()
     subprocess.check_call(["rm", "-f", temp_file])
@@ -123,7 +124,7 @@ def dispatch(args, extra_args=None):
     aha_map_log = app_dir / Path("log/aha_map.log")
     aha_sta_log = app_dir / Path("log/aha_sta.log")
     aha_glb_log = app_dir / Path("log/aha_glb.log")
-    
+
     # variable to store all results
     report_items = {}
 

--- a/aha/util/report.py
+++ b/aha/util/report.py
@@ -115,6 +115,28 @@ def get_array_dimension():
     return results
 
 
+def get_num_tracks():
+    results = {}
+    results["#Tracks"] = 0
+    # use grep to pre-parse the verilog file
+    temp_file = "/aha/garnet/grep_tiles.txt"
+    with open(temp_file, "w") as f_temp:
+        cmd = ["grep", "^module SB_ID", "/aha/garnet/garnet.v"]
+        subprocess.check_call(cmd, stdout=f_temp)
+    # parse the grep results
+    pattern = re.compile(r"^module\sSB_ID\d+_(\d+)TRACKS")
+    with open(temp_file, "r") as f_temp:
+        line = f_temp.readline()
+        while line:
+            m = pattern.match(line)
+            if m:
+                results["#Tracks"] = int(m.group(1))
+                break
+            line = f_temp.readline()
+    subprocess.check_call(["rm", "-f", temp_file])
+    return results
+
+
 def dispatch(args, extra_args=None):
     args.app = Path(args.app)
     app_dir = Path(f"{args.aha_dir}/Halide-to-Hardware/apps/hardware_benchmarks/{args.app}")
@@ -130,6 +152,7 @@ def dispatch(args, extra_args=None):
 
     # parse the log files
     report_items.update(get_array_dimension())
+    report_items.update(get_num_tracks())
     report_items.update(get_map_results(aha_map_log))
     report_items.update(get_sta_results(aha_sta_log))
     report_items.update(get_glb_results(aha_glb_log))

--- a/aha/util/sta.py
+++ b/aha/util/sta.py
@@ -13,14 +13,16 @@ def add_subparser(subparser):
 
 def subprocess_call_log(cmd, cwd, log, log_file_path):
     if log:
-        proc = subprocess.Popen(
-            cmd,
-            cwd=cwd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-        subprocess.check_call(["tee", log_file_path, "-a"], stdin=proc.stdout)
-        proc.wait()
+        print("[log] Command  : {}".format(cmd))
+        print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
+        with open(log_file_path, "a") as flog:
+            subprocess.check_call(
+                cmd,
+                cwd=cwd,
+                stdout=flog,
+                stderr=flog
+            )
+        print("done")
     else:
         subprocess.check_call(
             cmd,

--- a/aha/util/sta.py
+++ b/aha/util/sta.py
@@ -13,7 +13,7 @@ def add_subparser(subparser):
 
 def subprocess_call_log(cmd, cwd, log, log_file_path):
     if log:
-        print("[log] Command  : {}".format(cmd))
+        print("[log] Command  : {}".format(" ".join(cmd)))
         print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
         with open(log_file_path, "a") as flog:
             subprocess.check_call(
@@ -44,7 +44,7 @@ def dispatch(args, extra_args=None):
         subprocess.check_call(["rm", "-f", log_file_path])
 
     subprocess_call_log (
-        cmd=[sys.executable, "sta.py", "-a", app_dir]  + extra_args,
+        cmd=[sys.executable, "sta.py", "-a", str(app_dir)]  + extra_args,
         cwd=args.aha_dir / "archipelago/archipelago",
         log=args.log,
         log_file_path=log_file_path

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'pydot',
         'requirements-parser',
         'tabulate',
+        'pandas'
     ],
     setup_requires = [
         'networkx',


### PR DESCRIPTION
Add a bunch of new stuff to the aha report utility. Please merge this with a squash merge to reduce the number of commits in the master repo.

* now `--log` doesn't print stdout/stderr in the terminal, it redirects those to a log file under `apps/log`
* now `--log` is added to the following aha utilities:
  * `aha halide`
  * `aha map`
  * `aha pipeline`
  * `aha sta`
  * `aha glb`
* now `aha report` supports more reporting items
  * array size
  * PE, MEM total numbers
  * used resources numbers from `aha map`
  * critical path and maximum frequency
  * kernel execution cycles
  * tag (use this to label your run)
  * time stamp
* now `aha report` supports csv dump
  * use `--dump-report` to enable
  * by default, a file called `aha_report.csv` will be generated under `/aha/garnet`
  * you can change the location by `--dump-report-location`
  * each run of `aha report --dump-report` will append a row into that csv file
  * you can check the csv file in tools like excel