### PR TITLE
Python package packaging version 22 broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN make sam
 RUN source /aha/bin/activate && pip install scipy numpy pytest && pip install -e .
 
 WORKDIR /aha
-RUN source bin/activate && pip install wheel six && pip install systemrdl-compiler peakrdl-html && pip install -e . && aha deps install
+RUN source bin/activate && pip install wheel six && pip install systemrdl-compiler peakrdl-html && pip install -e . && pip install packaging==21.3 && aha deps install
 
 WORKDIR /aha
 


### PR DESCRIPTION
packaging version 22 throws errors when a setup.py has a wildcard in the version requirements of a dependency in the install_requires list. For now fixing the version of packaging to 21.3.