### PR TITLE
Aha pr retry hot fix

### DIFF
--- a/.buildkite/bin/update-pr-repo.sh
+++ b/.buildkite/bin/update-pr-repo.sh
@@ -42,7 +42,7 @@ elif expr "$BUILDKITE_MESSAGE" : "PR from " > /dev/null; then
         return
     fi
     BUILDKITE_PULL_REQUEST_REPO="$u"
-    echo '- Found BUILDKITE_PULL_REQUEST_REPO="$u"'
+    echo "- Found BUILDKITE_PULL_REQUEST_REPO '$u'"
 
     # OMG also need to reconstruct the NUMBER of the pull request.
     # Can find it by searching PR's for the appropriate commit SHA
@@ -62,7 +62,7 @@ elif expr "$BUILDKITE_MESSAGE" : "PR from " > /dev/null; then
     url_pr=`curl --location --silent \
       -H "Accept: application/vnd.github+json" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
-      https://api.github.com/repos/${user_repo}/pulls \
+      "https://api.github.com/repos/${user_repo}/pulls?state=all" \
       | egrep '"url.*pull|"head|"base|"sha' \
       | tr -d '",' | awk "$awkscript"`
 

--- a/.buildkite/bin/update-pr-repo.sh
+++ b/.buildkite/bin/update-pr-repo.sh
@@ -32,7 +32,11 @@ elif expr "$BUILDKITE_MESSAGE" : "PR from " > /dev/null; then
     echo "- Found submod '$submod'"
 
     echo '- Find full path of submod e.g. "https://github.com/stanfordaha/canal"'
-    if ! u=`git config --file .gitmodules --get submodule.${submod}.url`; then
+    if [ "$submod" == "aha" ]; then
+        u="https://github.com/stanfordaha/aha"
+        echo '- Oops haha not a submod, this is the aha parent repo'
+
+    elif ! u=`git config --file .gitmodules --get submodule.${submod}.url`; then
         echo "- ERROR cannot find path for submodule '$submod'"
         echo "- Could not (re)set BUILDKITE_PULL_REQUEST_REPO, BUILDKITE_PULL_REQUEST"
         return


### PR DESCRIPTION
Fixes three problems that emerged after the previous pull
- pushing new changes to an existing pull request from a submodule did not correctly rerun aha-flow check CI tests
- pushing new changes to a closed pull request caused problems that are now handled better
- prev version correctly handled pull request triggers from aha repo submodules BUT NOT so much for pull requests from the parent aha repo itself
