### PR TITLE
Remove dev-branch detritus

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,16 +32,6 @@ steps:
         git clean -ffxdq
         set +x
 
-        # Use this hack to (temporarily) use dev branches during development
-        USING_MASTER=; DEV=aha-no-heroku-cleanup
-        if [ "$$DEV" ]; then
-            git fetch -v --prune -- origin $$DEV || USING_MASTER=true
-            git checkout $$DEV                   || USING_MASTER=true
-            if ! [ "$$USING_MASTER" ]; then
-                msg="### WARNING Using dev branch '$${DEV}' instead of master"
-                buildkite-agent annotate --style "warning" --context dev "$$msg"
-            fi
-        fi
         bin=$BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/bin
 
         # Make sure env var BUILDKITE_PULL_REQUEST_REPO is set correctly


### PR DESCRIPTION
Now that `aha-no-heroku-cleanup` has been merged to master, we won't need this annoying warning-message code anymore.