### PR TITLE
With any luck, this will finally fix our root-owned temp dir problems

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,7 +100,6 @@ steps:
         image: garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}
         volumes:
           - "/cad/:/cad"
-          - "./temp:/buildkite:rw"
         # skip-checkout: true
         mount-checkout: false
         propagate-environment: true
@@ -167,6 +166,7 @@ steps:
           if [ "$$BUILDKITE_COMMAND_EXIT_STATUS" == 0 ]; then
               test -f temp/.TEST && export BUILDKITE_COMMAND_EXIT_STATUS=13
           fi
+          /bin/rm -rf temp
 
           # status-update will magically override "success" with "failure" as appropriate!
           # (Based on BUILDKITE_COMMAND_EXIT_STATUS and BUILDKITE_LAST_HOOK_EXIT_STATUS)


### PR DESCRIPTION
It's a very simple one-line fixed, but I added an extra line for paranoia's sake.
I'm going to wait for the tests to complete and then finalize the pull.

A little more explanation: It appears that if you mount a non-existent local directory to a docker container, the container creates the directory for you and gives it root ownership (!) (seems like an egregious security hole, but what do I know). The amber gold test, which does not need or use temp at all, was doing exactly that, because the docker setup was cut-n-pasted from another step that actually does use temp. So I deleted the mount point for the amber-gold-check step.

I also included a delete-temp-dir cleanup line in the other step, which is maybe nice to have for completeness, but should not really be necessary because that step creates temp with (non-root permission) before trying to mount it in the container.