### PR TITLE
Aha smaller docker image2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,7 +67,7 @@ steps:
   - set -x; docker images; docker ps;
 
   - echo "--- Creating garnet Image"
-  - docker build . -t "garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}"
+  - docker build . --progress=plain -t "garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}"
 
   - echo "--- Pruning Docker Images"
   - yes | docker image prune -a --filter "until=6h" --filter=label='description=garnet' || true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,7 +67,7 @@ steps:
   - set -x; docker images; docker ps;
 
   - echo "--- Creating garnet Image"
-  - docker build . --progress=plain -t "garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}"
+  - docker build . -t "garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}"
 
   - echo "--- Pruning Docker Images"
   - yes | docker image prune -a --filter "until=6h" --filter=label='description=garnet' || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
 COPY ./sam /aha/sam
 COPY ./.git /aha/.git
 WORKDIR /aha/sam
-RUN make sam
+RUN make sam && /bin/rm -rf /aha/.git
 RUN source /aha/bin/activate && pip install scipy numpy pytest && pip install -e .
 
 # Install torch (need big tmp folder)

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,10 @@ COPY . /aha
 WORKDIR /aha
 RUN \
   echo foo && \
-  du -sh /aha/* | egrep '^[0-9.]*[GM] ' | sort -rn && \
-  ls -lhd /aha/clockwork/soda_codes                && \
-  /bin/rm -rf /aha/clockwork                       && \
-  du -sh /aha/* | egrep '^[0-9.]*[GM] ' | sort -rn && \
+  du -sh /aha/* | egrep '^[0-9.]*[GM]' | sort -rn && \
+  ls -lhd /aha/clockwork/soda_codes               && \
+  /bin/rm -rf /aha/clockwork                      && \
+  du -sh /aha/* | egrep '^[0-9.]*[GM]' | sort -rn && \
   echo DONE
 RUN python -m venv .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -192,6 +192,7 @@ ENV USER=docker
 #     "+(0):WARN:0: Directory '/root/.modules' not found"
 
 RUN echo "source /aha/bin/activate" >> /root/.bashrc && \
+    echo "/aha/aha/bin/restore-halide-distrib.sh" >> /root/.bashrc
     echo "mkdir -p /root/.modules" >> /root/.bashrc && \
     echo "source /cad/modules/tcl/init/sh" >> /root/.bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ SHELL ["/bin/bash", "--login", "-c"]
 COPY . /aha
 WORKDIR /aha
 RUN \
+  echo foo && \
   du -sh /aha/* | egrep '^[0-9.]*[GM] ' | sort -rn && \
   ls -lhd /aha/clockwork/soda_codes                && \
   /bin/rm -rf /aha/clockwork                       && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,12 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Install AHA Tools
 COPY . /aha
 WORKDIR /aha
+RUN \
+  du -sh /aha/* | egrep '^[0-9.]*[GM] ' | sort -rn && \
+  ls -lhd /aha/clockwork/soda_codes                && \
+  /bin/rm -rf /aha/clockwork                       && \
+  du -sh /aha/* | egrep '^[0-9.]*[GM] ' | sort -rn && \
+  echo DONE
 RUN python -m venv .
 
 # Pono
@@ -135,10 +141,13 @@ RUN ./misc/install_deps_ahaflow.sh && \
     echo -n "BEFORE CLEANUP: " && du -hs /aha/clockwork && \
     echo "# cleanup: 440M removed with barvinok 'make clean'" && \
     (cd /aha/clockwork/barvinok-0.41; make clean) && \
-    echo "# cleanup: 140M soda_codes removed" && \
+    echo "# cleanup: removing 140M soda_codes?" && \
     /bin/rm -rf /aha/clockwork/soda_codes/ && \
     echo -n "AFTER  CLEANUP: " && du -hs /aha/clockwork && \
     echo DONE
+
+# AFTER  CLEANUP: 970M	/aha/clockwork
+
 
 # Halide-to-Hardware
 COPY ./Halide-to-Hardware /aha/Halide-to-Hardware

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,8 @@ RUN apt-get update && \
 SHELL ["/bin/bash", "--login", "-c"]
 
 # Bring in aha repo, prepare python environment
-COPY . /aha
-WORKDIR /aha
-RUN python -m venv .
+WORKDIR /
+RUN mkdir /aha && cd /aha && python -m venv .
 
 # Pono
 COPY ./pono /aha/pono

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ RUN echo "source /aha/bin/activate"               >> /root/.bashrc && \
 
 # Restore halide distrib files on every container startup
 # (bashrc only happens on interactive login)
-ENTRYPOINT /aha/aha/bin/restore-halide-distrib.sh
+ENTRYPOINT [ "/aha/aha/bin/restore-halide-distrib.sh" ]
 
 
 # Cleanup / image-size-reduction notes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,10 @@ RUN \
         pip install -e ./pono/deps/smt-switch/build/python && \
         pip install -e pono/build/python/
 
+COPY . /aha
+WORKDIR /aha
+RUN echo hello
+
 # CoreIR
 WORKDIR /aha
 COPY ./coreir /aha/coreir

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
 # Sam
 COPY ./sam /aha/sam
 WORKDIR /aha/sam
-RUN make sam
+RUN make -o submodules sam
 RUN source /aha/bin/activate && pip install scipy numpy pytest && pip install -e .
 
 # Install torch (need big tmp folder)

--- a/Dockerfile
+++ b/Dockerfile
@@ -174,10 +174,14 @@ ENV USER=docker
 #     "+(0):WARN:0: Directory '/root/.modules' not found"
 
 RUN echo "source /aha/bin/activate"               >> /root/.bashrc && \
-    echo "/aha/aha/bin/restore-halide-distrib.sh" >> /root/.bashrc && \
     echo "mkdir -p /root/.modules"                >> /root/.bashrc && \
     echo "source /cad/modules/tcl/init/sh"        >> /root/.bashrc && \
     echo DONE
+
+# Restore halide distrib files on every container startup
+# (bashrc only happens on interactive login)
+ENTRYPOINT /aha/aha/bin/restore-halide-distrib.sh
+
 
 # Cleanup / image-size-reduction notes:
 # 

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,13 @@ RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
 
 # Sam
 COPY ./sam /aha/sam
-COPY ./.git /aha/.git
+
+# did not work
+# COPY ./.git /aha/.git
+
+# try this intead :(
+COPY . /aha
+
 WORKDIR /aha/sam
 RUN make sam && /bin/rm -rf /aha/.git
 RUN source /aha/bin/activate && pip install scipy numpy pytest && pip install -e .
@@ -167,7 +173,7 @@ RUN source bin/activate && \
 
 # Bring in aha repo. Do this as late as possible,
 # since nothing after this will be cached probably.
-COPY . /aha
+# COPY . /aha
 WORKDIR /aha
 RUN source bin/activate && \
   pip install -e . && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,8 +143,9 @@ RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
 
 # Sam
 COPY ./sam /aha/sam
+COPY ./.git /aha/.git
 WORKDIR /aha/sam
-RUN make -o submodules sam
+RUN make sam
 RUN source /aha/bin/activate && pip install scipy numpy pytest && pip install -e .
 
 # Install torch (need big tmp folder)

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,8 +137,8 @@ WORKDIR /aha/Halide-to-Hardware
 RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
     echo "Cleanup: 200M lib, 400M gch, 200M distrib, 100M llvm" && \
       rm -rf lib/* && \
-      rm -rf /aha/Halide-to-Hardware/include/Halide.h.gch/ && \
-      rm -rf /aha/Halide-to-Hardware/distrib/{bin,lib}; touch /tmp/restore_once && \
+      rm -rf /aha/Halide-to-Hardware/include/Halide.h.gch/  && \
+      rm -rf /aha/Halide-to-Hardware/distrib/{bin,lib}      && \
       rm -rf /aha/Halide-to-Hardware/bin/build/llvm_objects && \
     echo DONE    
 
@@ -176,10 +176,15 @@ ENV USER=docker
 RUN echo "source /aha/bin/activate"               >> /root/.bashrc && \
     echo "mkdir -p /root/.modules"                >> /root/.bashrc && \
     echo "source /cad/modules/tcl/init/sh"        >> /root/.bashrc && \
+    echo 'echo ""                                      ' >> /root/.bashrc && \
+    echo 'echo "For pre-compiled Halide 'gch' headers:"' >> /root/.bashrc && \
+    echo 'echo "    cd /aha/Halide-to-Hardware"        ' >> /root/.bashrc && \
+    echo 'echo "    rm include/Halide.h"               ' >> /root/.bashrc && \
+    echo 'echo "    make include/Halide.h"             ' >> /root/.bashrc && \
+    echo 'echo ""                                      ' >> /root/.bashrc && \
     echo DONE
 
 # Restore halide distrib files on every container startup
-# (bashrc only happens on interactive login)
 ENTRYPOINT [ "/aha/aha/bin/restore-halide-distrib.sh" ]
 
 
@@ -191,7 +196,7 @@ ENTRYPOINT [ "/aha/aha/bin/restore-halide-distrib.sh" ]
 # - if you don't delete files in the same layer (RUN command) where
 #   they were created, you don't get any space savings in the image.
 #
-# - cannot do "make delete" in `/aha/pono/deps/smt-switch/build`,
+# - cannot do "make clean" in `/aha/pono/deps/smt-switch/build`,
 #   because it deletes `smt-switch/build/python`, which is where
 #   smt-switch is pip-installed :(
 #   This should probably be an issue or a FIXME in pono or something.

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,17 +135,25 @@ RUN ./misc/install_deps_ahaflow.sh && \
     echo -n "BEFORE CLEANUP: " && du -hs /aha/clockwork && \
     echo "# cleanup: 440M removed with barvinok 'make clean'" && \
     (cd /aha/clockwork/barvinok-0.41; make clean) && \
-    echo -n "AFTER  CLEANUP: " && du -hs /aha/clockwork && \
+    echo -n "AFTER  CLEANUP/barvinok: " && du -hs /aha/clockwork && \
+    /bin/rm -rf /aha/clockwork/*.o /aha/clockwork/bin/*.o && \
+    echo -n "AFTER  CLEANUP/dot-oh: " && du -hs /aha/clockwork && \
     echo DONE
-
-# AFTER  CLEANUP: 970M	/aha/clockwork
-
 
 # Halide-to-Hardware
 COPY ./Halide-to-Hardware /aha/Halide-to-Hardware
 WORKDIR /aha/Halide-to-Hardware
 RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
-    rm -rf lib/*
+    echo -n "BEFORE CLEANUP: " && du -hs /aha/Halide-to-Hardware && \
+    rm -rf lib/* && \
+    echo -n "AFTER  CLEANUP/lib: " && du -hs /aha/Halide-to-Hardware && \
+    /bin/rm -rf /aha/Halide-to-Hardware/include/Halide.h.gch/ && \
+    echo -n "AFTER  CLEANUP/gch: " && du -hs /aha/Halide-to-Hardware && \
+    /bin/rm -rf /aha/Halide-to-Hardware/distrib/{bin,lib}; touch /tmp/restore_once && \
+    echo -n "AFTER  CLEANUP/dist: " && du -hs /aha/Halide-to-Hardware && \
+    /bin/rm -rf /aha/Halide-to-Hardware/bin/build/llvm_objects && \
+    echo -n "AFTER  CLEANUP/llvm: " && du -hs /aha/Halide-to-Hardware && \
+    echo DONE    
 
 # Sam
 WORKDIR /aha/sam

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,10 +191,11 @@ ENV USER=docker
 # Create a /root/.modules so as to avoid this warning on startup:
 #     "+(0):WARN:0: Directory '/root/.modules' not found"
 
-RUN echo "source /aha/bin/activate" >> /root/.bashrc && \
-    echo "/aha/aha/bin/restore-halide-distrib.sh" >> /root/.bashrc
-    echo "mkdir -p /root/.modules" >> /root/.bashrc && \
-    echo "source /cad/modules/tcl/init/sh" >> /root/.bashrc
+RUN echo "source /aha/bin/activate"               >> /root/.bashrc && \
+    echo "/aha/aha/bin/restore-halide-distrib.sh" >> /root/.bashrc && \
+    echo "mkdir -p /root/.modules"                >> /root/.bashrc && \
+    echo "source /cad/modules/tcl/init/sh"        >> /root/.bashrc && \
+    echo DONE
 
 # Cleanup / image-size-reduction notes:
 # 

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ COPY ./sam /aha/sam
 COPY . /aha
 
 WORKDIR /aha/sam
-RUN make sam && /bin/rm -rf /aha/.git
+RUN make sam
 RUN source /aha/bin/activate && pip install scipy numpy pytest && pip install -e .
 
 # Install torch (need big tmp folder)

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,8 @@ RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
     echo DONE    
 
 # Sam
-COPY ./sam /aha/sam
+# don't need this, we copy all of /aha just down there a bit, see?
+# COPY ./sam /aha/sam
 
 # did not work
 # COPY ./.git /aha/.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Bring in aha repo, prepare python environment
 COPY . /aha
 WORKDIR /aha
+RUN pip install Cython==0.29 
 RUN python -m venv .
 
 # Pono
@@ -73,7 +74,7 @@ WORKDIR /aha/pono
 RUN \
   : SETUP && \
       source /aha/bin/activate && \
-      pip install Cython==0.29 pytest toml scikit-build==0.13.0 && \
+      pip install pytest toml scikit-build==0.13.0 && \
   : FLEX && \
       apt-get update && apt-get install -y flex && \
   : BISON && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,13 +64,6 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Install AHA Tools
 COPY . /aha
 WORKDIR /aha
-RUN \
-  echo foo && \
-  du -sh /aha/* | egrep '^[0-9.]*[GM]' | sort -rn && \
-  ls -lhd /aha/clockwork/soda_codes               && \
-  /bin/rm -rf /aha/clockwork                      && \
-  du -sh /aha/* | egrep '^[0-9.]*[GM]' | sort -rn && \
-  echo DONE
 RUN python -m venv .
 
 # Pono
@@ -142,8 +135,6 @@ RUN ./misc/install_deps_ahaflow.sh && \
     echo -n "BEFORE CLEANUP: " && du -hs /aha/clockwork && \
     echo "# cleanup: 440M removed with barvinok 'make clean'" && \
     (cd /aha/clockwork/barvinok-0.41; make clean) && \
-    echo "# cleanup: removing 140M soda_codes?" && \
-    /bin/rm -rf /aha/clockwork/soda_codes/ && \
     echo -n "AFTER  CLEANUP: " && du -hs /aha/clockwork && \
     echo DONE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,7 @@ RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
     echo DONE    
 
 # Sam
+COPY ./sam /aha/sam
 WORKDIR /aha/sam
 RUN make sam
 RUN source /aha/bin/activate && pip install scipy numpy pytest && pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,9 @@ RUN apt-get update && \
 # Switch shell to bash
 SHELL ["/bin/bash", "--login", "-c"]
 
-# Bring in aha repo, prepare python environment
+# Prepare python environment
 WORKDIR /
-RUN mkdir /aha && cd /aha && python -m venv .
+RUN mkdir -p /aha && cd /aha && python -m venv .
 
 # Pono
 COPY ./pono /aha/pono
@@ -99,10 +99,6 @@ RUN \
         source /aha/bin/activate && \
         pip install -e ./pono/deps/smt-switch/build/python && \
         pip install -e pono/build/python/
-
-COPY . /aha
-WORKDIR /aha
-RUN echo hello
 
 # CoreIR
 WORKDIR /aha
@@ -164,9 +160,19 @@ RUN source bin/activate && \
   pip install urllib3==1.26.15 && \
   pip install wheel six && \
   pip install systemrdl-compiler peakrdl-html && \
-  pip install -e . && \
   pip install packaging==21.3 && \
+  echo DONE
+
+# Bring in aha repo. Do this as late as possible,
+# since nothing after this will be cached probably.
+COPY . /aha
+WORKDIR /aha
+RUN source bin/activate && \
+  pip install -e . && \
   aha deps install
+
+
+
 
 WORKDIR /aha
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Bring in aha repo, prepare python environment
 COPY . /aha
 WORKDIR /aha
-RUN pip install Cython==0.29 
 RUN python -m venv .
 
 # Pono
@@ -73,8 +72,7 @@ COPY ./aha/bin/setup-smt-switch.sh /aha/pono/contrib/
 WORKDIR /aha/pono
 RUN \
   : SETUP && \
-      source /aha/bin/activate && \
-      pip install pytest toml scikit-build==0.13.0 && \
+      pip install Cython==0.29 pytest toml scikit-build==0.13.0 && \
   : FLEX && \
       apt-get update && apt-get install -y flex && \
   : BISON && \
@@ -99,6 +97,7 @@ RUN \
       cd /aha/pono && ./configure.sh --python && \
       cd /aha/pono/build && make -j4 && pip install -e ./python && \
       cd /aha && \
+        source /aha/bin/activate && \
         pip install -e ./pono/deps/smt-switch/build/python && \
         pip install -e pono/build/python/
 

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -x
+echo "--- Restore /aha/Halide-to-Hardware/distrib/{bin,lib}"
+f=/tmp/restore_once
+d=/aha/Halide-to-Hardware/distrib
+if test -e $f; then
+    cd $d;
+    tar xvf halide.tgz halide/bin; mv halide/bin bin
+    tar xvf halide.tgz halide/lib; mv halide/lib lib
+    rm $f
+else
+    echo "Already restored, nothing to do"
+fi
+ls -lh /aha/Halide-to-Hardware/distrib/{bin,lib}/*
+echo ""

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -19,7 +19,6 @@ echo "--- Restore /aha/Halide-to-Hardware/distrib/{bin,lib}"
     cd /aha/Halide-to-Hardware/distrib
     tar xvf halide.tgz halide/bin; mv halide/bin bin
     tar xvf halide.tgz halide/lib; mv halide/lib lib
-    rm $f
 )
 echo "halide/distrib restored:"
 ls -lh /aha/Halide-to-Hardware/distrib/{bin,lib}/*

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -32,6 +32,7 @@ fi
 ls -lh /aha/Halide-to-Hardware/distrib/{bin,lib}/*
 echo ""
 
+echo "Executing '$@'"
 # # When this script runs as a Dockerfile ENTRYPOINT, this next line
 # # allows execution of further commands passed via e.g. "docker run"
-# exec "$@"
+exec "$@"

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -31,3 +31,7 @@ else
 fi
 ls -lh /aha/Halide-to-Hardware/distrib/{bin,lib}/*
 echo ""
+
+# When this script runs as a Dockerfile ENTRYPOINT, this next line
+# allows execution of further commands passed via e.g. "docker run"
+exec "$@"

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
-set -x
+
+# What does this script do?
+
+# To save space (400M!), Dockerfile deletes halide bin and lib "distrib" files.
+# When the user first launches a container in the resulting image, this script
+# restores them from a compressed tar file that conveniently already exists(!)
+
+# 2. Dockerfile also deletes 400M worth of "Halide.h.gch" header files, which
+# I'm not sure if anyone needs or uses. This script, on first container launch,
+# tells how to quickly restore them (takes about a minute).
+
+# (This script is designed to be run from the aha docker container's ".bashrc")
+
 echo "--- Restore /aha/Halide-to-Hardware/distrib/{bin,lib}"
 f=/tmp/restore_once
 d=/aha/Halide-to-Hardware/distrib
@@ -8,8 +20,14 @@ if test -e $f; then
     tar xvf halide.tgz halide/bin; mv halide/bin bin
     tar xvf halide.tgz halide/lib; mv halide/lib lib
     rm $f
+    echo "halide/distrib restored."
+    echo ""
+    echo "If you want pre-compiled Halide 'gch' headers:"
+    echo "    cd /aha/Halide-to-Hardware"
+    echo "    rm include/Halide.h"
+    echo "    make include/Halide.h"
 else
-    echo "Already restored, nothing to do"
+    echo "Already restored, nothing to do."
 fi
 ls -lh /aha/Halide-to-Hardware/distrib/{bin,lib}/*
 echo ""

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -17,6 +17,7 @@ pwd
 f=/tmp/restore_once
 d=/aha/Halide-to-Hardware/distrib
 if test -e $f; then (
+    cd $d
     tar xvf halide.tgz halide/bin; mv halide/bin bin
     tar xvf halide.tgz halide/lib; mv halide/lib lib
     rm $f

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -2,43 +2,29 @@
 
 # What does this script do?
 
-# To save space (400M!), Dockerfile deletes halide bin and lib "distrib" files.
-# When the user first launches a container in the resulting image, this script
-# restores them from a compressed tar file that conveniently already exists(!)
+# To save space (400M!), Dockerfile deletes halide bin and lib
+# "distrib" files before building the final docker image.  When
+# someone uses the image to launch a container, this script restores
+# them from a compressed tar file that conveniently already exists(!)
 
 # 2. Dockerfile also deletes 400M worth of "Halide.h.gch" header files, which
 # I'm not sure if anyone needs or uses. This script, on first container launch,
 # tells how to quickly restore them (takes about a minute).
 
-# (This script is designed to be run from the aha docker container's ".bashrc")
+# This script is designed to be run as the docker image's "ENTRYPOINT",
+# i.e. it should run exactly *once* whenever a container is launched.
 
 echo "--- Restore /aha/Halide-to-Hardware/distrib/{bin,lib}"
-pwd
-f=/tmp/restore_once
-d=/aha/Halide-to-Hardware/distrib
-if test -e $f; then (
-    cd $d
+(
+    cd /aha/Halide-to-Hardware/distrib
     tar xvf halide.tgz halide/bin; mv halide/bin bin
     tar xvf halide.tgz halide/lib; mv halide/lib lib
     rm $f
-    echo "halide/distrib restored."
-    echo ""
-    echo "If you want pre-compiled Halide 'gch' headers:"
-    echo "    cd /aha/Halide-to-Hardware"
-    echo "    rm include/Halide.h"
-    echo "    make include/Halide.h"
-  )
-else
-    echo "Already restored, nothing to do."
-fi
+)
+echo "halide/distrib restored:"
 ls -lh /aha/Halide-to-Hardware/distrib/{bin,lib}/*
 echo ""
 
-echo foo
-pwd
-test -e /aha && cd /aha || echo okay
-
-echo "Executing '$@'"
-# # When this script runs as a Dockerfile ENTRYPOINT, this next line
-# # allows execution of further commands passed via e.g. "docker run"
+# When this script runs as a Dockerfile ENTRYPOINT, this next line
+# runs whatever commands get passed via e.g. "docker run"
 exec "$@"

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -13,10 +13,10 @@
 # (This script is designed to be run from the aha docker container's ".bashrc")
 
 echo "--- Restore /aha/Halide-to-Hardware/distrib/{bin,lib}"
+pwd
 f=/tmp/restore_once
 d=/aha/Halide-to-Hardware/distrib
-if test -e $f; then
-    cd $d;
+if test -e $f; then (
     tar xvf halide.tgz halide/bin; mv halide/bin bin
     tar xvf halide.tgz halide/lib; mv halide/lib lib
     rm $f
@@ -26,11 +26,16 @@ if test -e $f; then
     echo "    cd /aha/Halide-to-Hardware"
     echo "    rm include/Halide.h"
     echo "    make include/Halide.h"
+  )
 else
     echo "Already restored, nothing to do."
 fi
 ls -lh /aha/Halide-to-Hardware/distrib/{bin,lib}/*
 echo ""
+
+echo foo
+pwd
+test -e /aha && cd /aha || echo okay
 
 echo "Executing '$@'"
 # # When this script runs as a Dockerfile ENTRYPOINT, this next line

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -3,16 +3,12 @@
 # What does this script do?
 
 # To save space (400M!), Dockerfile deletes halide bin and lib
-# "distrib" files before building the final docker image.  When
-# someone uses the image to launch a container, this script restores
-# them from a compressed tar file that conveniently already exists(!)
-
-# 2. Dockerfile also deletes 400M worth of "Halide.h.gch" header files, which
-# I'm not sure if anyone needs or uses. This script, on first container launch,
-# tells how to quickly restore them (takes about a minute).
+# "distrib" files before building the final docker image.
+# This script restores them from a compressed tar file
+# that conveniently already exists(!)
 
 # This script is designed to be run as the docker image's "ENTRYPOINT",
-# i.e. it should run exactly *once* whenever a container is launched.
+# so that it will run exactly *once*, at initial container launch.
 
 echo "--- Restore /aha/Halide-to-Hardware/distrib/{bin,lib}"
 (

--- a/aha/bin/restore-halide-distrib.sh
+++ b/aha/bin/restore-halide-distrib.sh
@@ -32,6 +32,6 @@ fi
 ls -lh /aha/Halide-to-Hardware/distrib/{bin,lib}/*
 echo ""
 
-# When this script runs as a Dockerfile ENTRYPOINT, this next line
-# allows execution of further commands passed via e.g. "docker run"
-exec "$@"
+# # When this script runs as a Dockerfile ENTRYPOINT, this next line
+# # allows execution of further commands passed via e.g. "docker run"
+# exec "$@"


### PR DESCRIPTION
Speeds docker builds by doing cacheable layers first. Layers that are most likely to change, e.g. the one that copies the aha repo, go later in the `Dockerfile`. This reduces typical build time on our local machine from over an hour to less than 15 minutes.

Fixes "deprecated `tp_print`" warnings by installing Cython as `/usr/local/bin` instead of `/aha/bin`. No, I don't know why this works :(

Reduces docker image size by 1 GB by more aggressive cleanup after Halide build.

Introduces an image "ENTRYPOINT" script (`restore-halide-distrib.sh`) that restores a couple of the "cleaned-up" Halide files. The restoration only takes a couple of seconds. In return, the docker image is 400MB smaller than if the files were kept in place.

Cleans up a couple of comments and simplifies the code in a couple of places.