### PR TITLE
Regress daemon

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -198,8 +198,9 @@ steps:
   - apt install time
   - ls /aha
   - echo "--- PIP INSTALL importlib_resources"; pip install importlib_resources
-  - pip freeze
-  - (cd garnet && echo "garnet" && git rev-parse --verify HEAD)
+  - echo "--- PIP FREEZE"; pip freeze
+  - echo "--- GARNET UPDATE"; (cd garnet; git fetch origin; git checkout refactor)
+  - (cd garnet && echo -n "garnet " && git rev-parse --verify HEAD)
   # Run regression tests
   - if test -e /buildkite/DO_PR; then
       echo "Trigger came from submod repo pull request; use pr config";

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -197,8 +197,6 @@ steps:
   - apt update
   - apt install time
   - ls /aha
-  # Temporarily(?) install importlib_resources until we can update dockerfile maybe?
-  - echo "--- PIP INSTALL importlib_resources"; pip install importlib_resources
   - echo "--- PIP FREEZE"; pip freeze
   - echo "--- GARNET UPDATE"; (cd garnet; git fetch origin; git checkout refactor)
   - (cd garnet && echo -n "garnet " && git rev-parse --verify HEAD)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -197,6 +197,7 @@ steps:
   - apt update
   - apt install time
   - ls /aha
+  - echo "--- PIP INSTALL importlib_resources"; pip install importlib_resources
   - pip freeze
   - (cd garnet && echo "garnet" && git rev-parse --verify HEAD)
   # Run regression tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -208,7 +208,7 @@ steps:
     else
       echo "Trigger came from aha repo; use default config";
     fi;
-  - aha regress $$CONFIG
+  - aha regress $$CONFIG --daemon auto
   # We report success to the aha-flow app by removing the .TEST file,
   # which is created in the post-checkout hook and checked for in the
   # pre-exit hook.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -197,6 +197,7 @@ steps:
   - apt update
   - apt install time
   - ls /aha
+  # Temporarily(?) install importlib_resources until we can update dockerfile maybe?
   - echo "--- PIP INSTALL importlib_resources"; pip install importlib_resources
   - echo "--- PIP FREEZE"; pip freeze
   - echo "--- GARNET UPDATE"; (cd garnet; git fetch origin; git checkout refactor)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -202,7 +202,7 @@ steps:
   - apt install time
   - ls /aha
   - echo    "--- PIP FREEZE"; pip freeze
-  - echo    "--- GARNET UPDATE";   (cd garnet; git fetch origin; git checkout master)
+  # - echo    "--- GARNET UPDATE";   (cd garnet; git fetch origin; git checkout master)
   - echo -n "--- GARNET VERSION "; (cd garnet && git rev-parse --verify HEAD)
   # Run regression tests
   - if test -e /buildkite/DO_PR; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -202,6 +202,7 @@ steps:
   - apt install time
   - ls /aha
   - echo    "--- PIP FREEZE"; pip freeze
+  - echo    "--- GARNET UPDATE";   (cd garnet; git fetch origin; git checkout master)
   - echo -n "--- GARNET VERSION "; (cd garnet && git rev-parse --verify HEAD)
   # Run regression tests
   - if test -e /buildkite/DO_PR; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,7 @@
+# Now using daemon. To turn off daemon, search code below and change
+#   < aha regress $$CONFIG --daemon auto
+#   > aha regress $$CONFIG
+
 env:
   CONFIG: ${CONFIG:-daily}
 
@@ -197,9 +201,8 @@ steps:
   - apt update
   - apt install time
   - ls /aha
-  - echo "--- PIP FREEZE"; pip freeze
-  - echo "--- GARNET UPDATE"; (cd garnet; git fetch origin; git checkout refactor)
-  - (cd garnet && echo -n "garnet " && git rev-parse --verify HEAD)
+  - echo    "--- PIP FREEZE"; pip freeze
+  - echo -n "--- GARNET VERSION "; (cd garnet && git rev-parse --verify HEAD)
   # Run regression tests
   - if test -e /buildkite/DO_PR; then
       echo "Trigger came from submod repo pull request; use pr config";

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
-# Now using daemon. To turn off daemon, search code below and change
-#   < aha regress $$CONFIG --daemon auto
-#   > aha regress $$CONFIG
+# To turn daemon on or off, search code below and change to one of:
+#   aha regress $$CONFIG --daemon auto  # Use daemon
+#   aha regress $$CONFIG                # No daemon
 
 env:
   CONFIG: ${CONFIG:-daily}
@@ -202,7 +202,6 @@ steps:
   - apt install time
   - ls /aha
   - echo    "--- PIP FREEZE"; pip freeze
-  # - echo    "--- GARNET UPDATE";   (cd garnet; git fetch origin; git checkout master)
   - echo -n "--- GARNET VERSION "; (cd garnet && git rev-parse --verify HEAD)
   # Run regression tests
   - if test -e /buildkite/DO_PR; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ RUN source bin/activate && \
   pip install wheel six && \
   pip install systemrdl-compiler peakrdl-html && \
   pip install packaging==21.3 && \
+  pip install importlib_resources && \
   echo DONE
 
 # Pono

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -119,17 +119,13 @@ def dispatch(args, extra_args=None):
     # When running as daemon, must use non-blocking "Popen" and not "check_call"
     # if '--daemon' in extra_args and not 'use' in extra_args:
 
-    print(f"extra_args={extra_args}", flush=True)
-
     launch_daemon = False
     do_cmd = subprocess.check_call
     if '--daemon' in extra_args:
-        print(f"--- found the --daemon", flush=True)
-        print(f"--- does daemon exist yet?", flush=True)
         cmd = [sys.executable, "garnet.py", "--daemon", "status"]
         p = subprocess.run(cmd, text=True, cwd=args.aha_dir / "garnet",
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        print(f"--- daemon status returned: {p.stdout}", flush=True)
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # print(f"--- daemon status returned: {p.stdout}", flush=True)
 
         launch_daemon = 'no daemon found' in p.stdout
         if launch_daemon:

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -143,7 +143,7 @@ def dispatch(args, extra_args=None):
         do_cmd=do_cmd,
     )
 
-    # Daemon runs in the background; this tells us when the PNR is done
+    # Daemon runs in the background; need this to tell us when the PNR is done
     if need_daemon:
         print(f'--- BEGIN LAUNCHED NEW DAEMON in pnr; waiting now...')
         subprocess.run([sys.executable, 'garnet.py', '--daemon', 'wait'], cwd='/aha/garnet')

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -119,14 +119,22 @@ def dispatch(args, extra_args=None):
     # When running as daemon, must use non-blocking "Popen" and not "check_call"
     # if '--daemon' in extra_args and not 'use' in extra_args:
 
+    print(f"extra_args={extra_args}", flush=True)
+
     launch_daemon = False
     do_cmd = subprocess.check_call
     if '--daemon' in extra_args:
+        print(f"--- found the --daemon", flush=True)
+        print(f"--- does daemon exist yet?", flush=True)
         cmd = [sys.executable, "garnet.py", "--daemon", "status"]
         p = subprocess.run(cmd, text=True,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         launch_daemon = 'no daemon found' in p.stdout
-        if launch_daemon: do_cmd = subprocess.Popen
+        if launch_daemon:
+            print(f"--- found no daemon, setting do_cmd to Popen", flush=True)
+            do_cmd = subprocess.Popen
+        else:
+            print(f"--- found the daemon, leaving do_cmd alone", flush=True)
 
     subprocess_call_log (
         cmd=[sys.executable, "garnet.py"] + map_args + extra_args,

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -117,10 +117,16 @@ def dispatch(args, extra_args=None):
     ]
 
     # When running as daemon, must use non-blocking "Popen" and not "check_call"
-    if '--daemon' in extra_args and not 'use' in extra_args:
-        do_cmd = subprocess.Popen
-    else:
-        do_cmd = subprocess.check_call
+    # if '--daemon' in extra_args and not 'use' in extra_args:
+
+    launch_daemon = False
+    do_cmd = subprocess.check_call
+    if '--daemon' in extra_args:
+        cmd = [sys.executable, "garnet.py", "--daemon", "status"]
+        p = subprocess.run(cmd, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        launch_daemon = 'no daemon found' in p.stdout
+        if launch_daemon: do_cmd = subprocess.Popen
 
     subprocess_call_log (
         cmd=[sys.executable, "garnet.py"] + map_args + extra_args,
@@ -131,9 +137,9 @@ def dispatch(args, extra_args=None):
         do_cmd=do_cmd,
     )
 
-    # When running as a daemon, this will tell us when the PNR is done
-    if '--daemon' in extra_args:
-        print(f'--- BEGIN DAEMON FOUND in pnr; waiting now...')
+    # When launching a new daemon, this will tell us when the PNR is done
+    if launch_daemon:
+        print(f'--- BEGIN LAUNCHED NEW DAEMON in pnr; waiting now...')
         subprocess.run([sys.executable, 'garnet.py', '--daemon', 'wait'], cwd='/aha/garnet')
 
     # generate meta_data.json file

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -129,6 +129,8 @@ def dispatch(args, extra_args=None):
         cmd = [sys.executable, "garnet.py", "--daemon", "status"]
         p = subprocess.run(cmd, text=True,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        print(f"--- daemon status returned: {p.stdout}", flush=True)
+
         launch_daemon = 'no daemon found' in p.stdout
         if launch_daemon:
             print(f"--- found no daemon, setting do_cmd to Popen", flush=True)

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -127,7 +127,7 @@ def dispatch(args, extra_args=None):
         print(f"--- found the --daemon", flush=True)
         print(f"--- does daemon exist yet?", flush=True)
         cmd = [sys.executable, "garnet.py", "--daemon", "status"]
-        p = subprocess.run(cmd, text=True,
+        p = subprocess.run(cmd, text=True, cwd=args.aha_dir / "garnet",
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         print(f"--- daemon status returned: {p.stdout}", flush=True)
 

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -16,12 +16,14 @@ def add_subparser(subparser):
     parser.set_defaults(dispatch=dispatch)
 
 
-def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log"):
+def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log", do_cmd=subprocess.check_call):
+    if do_cmd == subprocess.check_call: print('--- PNR/scl: check_call (run) garnet.py')
+    elif do_cmd == subprocess.Popen:    print('--- PNR/scl: Popen (background) garnet.py')
     if log:
         print("[log] Command  : {}".format(" ".join(cmd)))
         print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
         with open(log_file_path, "a") as flog:
-            subprocess.check_call(
+            do_cmd(
                 cmd,
                 cwd=cwd,
                 env=env,
@@ -30,7 +32,7 @@ def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log"):
             )
         print("done")
     else:
-        subprocess.check_call(
+        do_cmd(
             cmd,
             env=env,
             cwd=cwd
@@ -114,14 +116,26 @@ def dispatch(args, extra_args=None):
         "--pipeline-pnr"
     ]
 
+    # When running as daemon, must use non-blocking "Popen" and not "check_call"
+    if '--daemon' in extra_args and not 'use' in extra_args:
+        do_cmd = subprocess.Popen
+    else:
+        do_cmd = subprocess.check_call
+
     subprocess_call_log (
         cmd=[sys.executable, "garnet.py"] + map_args + extra_args,
         cwd=args.aha_dir / "garnet",
         log=args.log,
         log_file_path=log_file_path,
-        env=env
+        env=env,
+        do_cmd=do_cmd,
     )
-    
+
+    # When running as a daemon, this will tell us when the PNR is done
+    if '--daemon' in extra_args:
+        print(f'--- BEGIN DAEMON FOUND in pnr; waiting now...')
+        subprocess.run([sys.executable, 'garnet.py', '--daemon', 'wait'], cwd='/aha/garnet')
+
     # generate meta_data.json file
     if not args.no_parse:
         if not str(args.app).startswith("handcrafted"):
@@ -139,3 +153,4 @@ def dispatch(args, extra_args=None):
                 env=env
             )
 
+    print('--- DONE PNR'); sys.stdout.flush(); sys.stderr.flush(); sys.stdin.flush()

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -16,7 +16,9 @@ def add_subparser(subparser):
     parser.set_defaults(dispatch=dispatch)
 
 
-def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log", do_cmd=subprocess.check_call):
+def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log",
+                        do_cmd=subprocess.check_call):
+    '''Can set e.g. do_cmd=Popen to run job in background'''
     # if do_cmd == subprocess.check_call: print('--- PNR/scl: check_call (run) garnet.py')
     # elif do_cmd == subprocess.Popen:    print('--- PNR/scl: Popen (background) garnet.py')
     if log:
@@ -116,10 +118,7 @@ def dispatch(args, extra_args=None):
         "--pipeline-pnr"
     ]
 
-    # When running as daemon, must use non-blocking "Popen" and not "check_call"
-    # if '--daemon' in extra_args and not 'use' in extra_args:
-
-    launch_daemon = False
+    need_daemon = False
     do_cmd = subprocess.check_call
     if '--daemon' in extra_args:
         cmd = [sys.executable, "garnet.py", "--daemon", "status"]
@@ -127,8 +126,9 @@ def dispatch(args, extra_args=None):
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # print(f"--- daemon status returned: {p.stdout}", flush=True)
 
-        launch_daemon = 'no daemon found' in p.stdout
-        if launch_daemon:
+        # When running as daemon, must use non-blocking "Popen" and not "check_call"
+        need_daemon = 'no daemon found' in p.stdout
+        if need_daemon:
             print(f"--- found no daemon, setting do_cmd to Popen", flush=True)
             do_cmd = subprocess.Popen
         else:
@@ -143,8 +143,8 @@ def dispatch(args, extra_args=None):
         do_cmd=do_cmd,
     )
 
-    # When launching a new daemon, this will tell us when the PNR is done
-    if launch_daemon:
+    # Daemon runs in the background; this tells us when the PNR is done
+    if need_daemon:
         print(f'--- BEGIN LAUNCHED NEW DAEMON in pnr; waiting now...')
         subprocess.run([sys.executable, 'garnet.py', '--daemon', 'wait'], cwd='/aha/garnet')
 

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -121,10 +121,11 @@ def dispatch(args, extra_args=None):
     need_daemon = False
     do_cmd = subprocess.check_call
     if '--daemon' in extra_args:
+
+        # Do a '--daemon status' to see if daemon exists yet
         cmd = [sys.executable, "garnet.py", "--daemon", "status"]
         p = subprocess.run(cmd, text=True, cwd=args.aha_dir / "garnet",
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        # print(f"--- daemon status returned: {p.stdout}", flush=True)
 
         # When running as daemon, must use non-blocking "Popen" and not "check_call"
         need_daemon = 'no daemon found' in p.stdout

--- a/aha/util/pnr.py
+++ b/aha/util/pnr.py
@@ -17,8 +17,8 @@ def add_subparser(subparser):
 
 
 def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log", do_cmd=subprocess.check_call):
-    if do_cmd == subprocess.check_call: print('--- PNR/scl: check_call (run) garnet.py')
-    elif do_cmd == subprocess.Popen:    print('--- PNR/scl: Popen (background) garnet.py')
+    # if do_cmd == subprocess.check_call: print('--- PNR/scl: check_call (run) garnet.py')
+    # elif do_cmd == subprocess.Popen:    print('--- PNR/scl: Popen (background) garnet.py')
     if log:
         print("[log] Command  : {}".format(" ".join(cmd)))
         print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -359,6 +359,7 @@ def dispatch(args, extra_args=None):
         t0, t1, t2 = test_dense_app("apps/resnet_output_stationary", width, height, layer=test, env_parameters=str(args.env_parameters))
         info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2])
         
+    print(f"+++ TIMING INFO", flush=True)
     print(tabulate(info, headers=["step", "total", "compile", "map", "test"]), flush=True)
 
 

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -329,7 +329,26 @@ def dispatch(args, extra_args=None):
         raise NotImplementedError(f"Unknown test config: {args.config}")
 
 
-    print(f"--- Running regression: {args.config}", flush=True)
+    # print(f"--- Running regression: {args.config}", flush=True)
+    # ------------------------------------------------------------------------
+
+
+
+    print(f"--- Running regression: DAEMONTEST", flush=True)
+    if True:
+        width, height = 28, 16
+        sparse_tests = [
+        ]
+        glb_tests = [
+            "apps/pointwise",
+            "apps/pointwise",
+        ]
+        resnet_tests = []
+
+
+
+
+    # ------------------------------------------------------------------------
     info = []
     t = gen_garnet(width, height)
     info.append(["garnet", t])

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -139,6 +139,12 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
     print(f"--- {testname} - pnr and pipelining", flush=True)
     start = time.time()
 
+    # To use daemon, call regress.py with args '--daemon auto'
+    # --- extra_args=['--daemon', 'auto']
+    use_daemon = []
+    if ('--daemon' in extra_args) and ('auto' in extra_args):
+        use_daemon = [ "--daemon", "auto" ]
+
     buildkite_call(
         [
             "aha",
@@ -148,7 +154,7 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
             "--height", str(height),
             "--daemon", "auto",
             "--env-parameters", env_parameters,
-        ] + layer_array
+        ] + use_daemon + layer_array
     )
     time_map = time.time() - start
 

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -140,7 +140,6 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
     print(f"--- {testname} - pnr and pipelining", flush=True)
     start = time.time()
 
-    print(f"env_parameters={env_parameters}", flush=True)
     buildkite_call(
         [
             "aha",

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -140,6 +140,7 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
     print(f"--- {testname} - pnr and pipelining", flush=True)
     start = time.time()
 
+    print(f"env_parameters={env_parameters}", flush=True)
     buildkite_call(
         [
             "aha",

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -32,7 +32,7 @@ def buildkite_call(command, env={}):
 
 
 def gen_garnet(width, height):
-    print("--- Generating Garnet")
+    print("--- Generating Garnet", flush=True)
     start = time.time()
     if not os.path.exists("/aha/garnet/garnet.v"):
         buildkite_call(
@@ -56,7 +56,7 @@ def generate_sparse_bitstreams(sparse_tests, width, height):
     if len(sparse_tests) == 0:
         return 0
     
-    print(f"--- mapping all tests")
+    print(f"--- mapping all tests", flush=True)
     start = time.time()
     env_vars = {"PYTHONPATH": "/aha/garnet/"}
     start = time.time()
@@ -99,14 +99,14 @@ def test_sparse_app(testname, test=""):
     env_vars = {"PYTHONPATH": "/aha/garnet/"}
 
     app_path = f"../../../garnet/SPARSE_TESTS/{testname}_0/GLB_DIR/{testname}_combined_seed_0"
-    print(app_path)
+    print(app_path, flush=True)
 
     try:
         subprocess.call(["make", "clean"], cwd=app_path)
     except:
         pass
 
-    print(f"--- {test} - glb testing")
+    print(f"--- {test} - glb testing", flush=True)
     start = time.time()
     buildkite_call(
         ["aha", "test", app_path, "--sparse", "--sparse-test-name", testname], env=env_vars,
@@ -121,7 +121,7 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
     print(f"--- {testname}")
     print(f"--- {testname} - compiling and mapping")
     app_path = "/aha/Halide-to-Hardware/apps/hardware_benchmarks/" + test
-    print(app_path)
+    print(app_path, flush=True)
 
     if layer is not None:
         layer_array = ["--layer", layer]
@@ -137,7 +137,7 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
     buildkite_call(["aha", "map", test, "--chain", "--env-parameters", env_parameters] + layer_array)
     time_compile = time.time() - start
 
-    print(f"--- {testname} - pnr and pipelining")
+    print(f"--- {testname} - pnr and pipelining", flush=True)
     start = time.time()
 
     buildkite_call(
@@ -152,7 +152,7 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
     )
     time_map = time.time() - start
 
-    print(f"--- {testname} - glb testing")
+    print(f"--- {testname} - glb testing", flush=True)
     start = time.time()
     buildkite_call(["aha", "test", test])
     time_test = time.time() - start
@@ -323,7 +323,7 @@ def dispatch(args, extra_args=None):
     else:
         raise NotImplementedError(f"Unknown test config: {args.config}")
 
-    print(f"--- Running regression: {args.config}")
+    print(f"--- Running regression: {args.config}", flush=True)
     info = []
     t = gen_garnet(width, height)
     info.append(["garnet", t])
@@ -342,7 +342,7 @@ def dispatch(args, extra_args=None):
         t0, t1, t2 = test_dense_app("apps/resnet_output_stationary", width, height, layer=test, env_parameters=str(args.env_parameters))
         info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2])
         
-    print(tabulate(info, headers=["step", "total", "compile", "map", "test"]))
+    print(tabulate(info, headers=["step", "total", "compile", "map", "test"]), flush=True)
 
 
 def gather_tests(tags):

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -148,6 +148,7 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
             test,
             "--width", str(width),
             "--height", str(height),
+            "--daemon auto",
             "--env-parameters", env_parameters,
         ] + layer_array
     )
@@ -162,6 +163,7 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
 
 
 def dispatch(args, extra_args=None):
+    print(f"--- extra_args={extra_args}", flush=True)
     sparse_tests = []
     if args.config == "fast":
         width, height = 4, 4

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -323,7 +323,24 @@ def dispatch(args, extra_args=None):
     else:
         raise NotImplementedError(f"Unknown test config: {args.config}")
 
+
     print(f"--- Running regression: {args.config}", flush=True)
+    ##################################################################
+
+    print(f"--- TEMPORARY OVERRIDE, running quick-dev regressions instead", flush=True)
+    width, height = 28, 16
+    sparse_tests = [
+            "matmul_ijk",
+    ]
+    glb_tests = [
+            "apps/pointwise",
+            "tests/ushift",
+            "tests/arith",
+            "tests/absolute",
+    ]
+    resnet_tests = []
+
+    ##################################################################
     info = []
     t = gen_garnet(width, height)
     info.append(["garnet", t])

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -115,7 +115,8 @@ def test_sparse_app(testname, test=""):
     return 0, 0, time_test
 
 
-def test_dense_app(test, width, height, layer=None, env_parameters="", extra_args=None):
+def test_dense_app(test, width, height, env_parameters, extra_args, layer=None,):
+    env_parameters = str(env_parameters)
     testname = layer if layer is not None else test
     print(f"--- {testname}")
     print(f"--- {testname} - compiling and mapping")
@@ -167,17 +168,7 @@ def test_dense_app(test, width, height, layer=None, env_parameters="", extra_arg
 
 
 def dispatch(args, extra_args=None):
-    print(f"--- extra_args={extra_args}", flush=True)
     sparse_tests = []
-    # ------------------------------------------------------------------------
-    # 
-    # 
-    # 
-    args.config = "pr"
-    # 
-    # 
-    # 
-    # ------------------------------------------------------------------------
     if args.config == "fast":
         width, height = 4, 4
         sparse_tests = [
@@ -356,11 +347,13 @@ def dispatch(args, extra_args=None):
         info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2])
 
     for test in glb_tests:
-        t0, t1, t2 = test_dense_app(test, width, height, env_parameters=str(args.env_parameters), extra_args=extra_args)
+        t0, t1, t2 = test_dense_app(test, 
+                                    width, height, args.env_parameters, extra_args)
         info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2])
 
     for test in resnet_tests:
-        t0, t1, t2 = test_dense_app("apps/resnet_output_stationary", width, height, layer=test, env_parameters=str(args.env_parameters))
+        t0, t1, t2 = test_dense_app("apps/resnet_output_stationary",
+                                    width, height, args.env_parameters, extra_args, layer=test)
         info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2])
         
     print(f"+++ TIMING INFO", flush=True)

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -148,7 +148,7 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
             test,
             "--width", str(width),
             "--height", str(height),
-            "--daemon auto",
+            "--daemon", "auto",
             "--env-parameters", env_parameters,
         ] + layer_array
     )

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -152,7 +152,6 @@ def test_dense_app(test, width, height, layer=None, env_parameters="", extra_arg
             test,
             "--width", str(width),
             "--height", str(height),
-            "--daemon", "auto",
             "--env-parameters", env_parameters,
         ] + use_daemon + layer_array
     )

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -169,6 +169,15 @@ def test_dense_app(test, width, height, layer=None, env_parameters=""):
 def dispatch(args, extra_args=None):
     print(f"--- extra_args={extra_args}", flush=True)
     sparse_tests = []
+    # ------------------------------------------------------------------------
+    # 
+    # 
+    # 
+    args.config = "pr"
+    # 
+    # 
+    # 
+    # ------------------------------------------------------------------------
     if args.config == "fast":
         width, height = 4, 4
         sparse_tests = [
@@ -335,26 +344,7 @@ def dispatch(args, extra_args=None):
         raise NotImplementedError(f"Unknown test config: {args.config}")
 
 
-    # print(f"--- Running regression: {args.config}", flush=True)
-    # ------------------------------------------------------------------------
-
-
-
-    print(f"--- Running regression: DAEMONTEST", flush=True)
-    if True:
-        width, height = 28, 16
-        sparse_tests = [
-        ]
-        glb_tests = [
-            "apps/pointwise",
-            "apps/pointwise",
-        ]
-        resnet_tests = []
-
-
-
-
-    # ------------------------------------------------------------------------
+    print(f"--- Running regression: {args.config}", flush=True)
     info = []
     t = gen_garnet(width, height)
     info.append(["garnet", t])

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -115,7 +115,7 @@ def test_sparse_app(testname, test=""):
     return 0, 0, time_test
 
 
-def test_dense_app(test, width, height, layer=None, env_parameters=""):
+def test_dense_app(test, width, height, layer=None, env_parameters="", extra_args=None):
     testname = layer if layer is not None else test
     print(f"--- {testname}")
     print(f"--- {testname} - compiling and mapping")
@@ -356,7 +356,7 @@ def dispatch(args, extra_args=None):
         info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2])
 
     for test in glb_tests:
-        t0, t1, t2 = test_dense_app(test, width, height, env_parameters=str(args.env_parameters))
+        t0, t1, t2 = test_dense_app(test, width, height, env_parameters=str(args.env_parameters), extra_args=extra_args)
         info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2])
 
     for test in resnet_tests:

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -327,22 +327,6 @@ def dispatch(args, extra_args=None):
 
 
     print(f"--- Running regression: {args.config}", flush=True)
-    ##################################################################
-
-    print(f"--- TEMPORARY OVERRIDE, running quick-dev regressions instead", flush=True)
-    width, height = 28, 16
-    sparse_tests = [
-            "matmul_ijk",
-    ]
-    glb_tests = [
-            "apps/pointwise",
-            "tests/ushift",
-            "tests/arith",
-            "tests/absolute",
-    ]
-    resnet_tests = []
-
-    ##################################################################
     info = []
     t = gen_garnet(width, height)
     info.append(["garnet", t])

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -142,8 +142,9 @@ def test_dense_app(test, width, height, layer=None, env_parameters="", extra_arg
     # To use daemon, call regress.py with args '--daemon auto'
     # --- extra_args=['--daemon', 'auto']
     use_daemon = []
-    if ('--daemon' in extra_args) and ('auto' in extra_args):
-        use_daemon = [ "--daemon", "auto" ]
+    if (extra_args):
+        if ('--daemon' in extra_args) and ('auto' in extra_args):
+            use_daemon = [ "--daemon", "auto" ]
 
     buildkite_call(
         [


### PR DESCRIPTION
This pull enables an option to use the new daemon-enabled `garnet.py` to speed regression tests. This option is currently ON by default. We can open a discussion if one or more reviewer(s) thinks that should be different...

Code changes include:
- updated `pnr.py` to use background daemon instead of doing pnr from scratch every time;
- updated `regress.py` to use this new `pnr.py`;
- added frequent `stdout flush` commands to try and improve stdout/stderr synchronization in regression log output.

The daemon saves approximately 90 seconds per dense app in a regression suite. (Sparse apps use a different mechanism for pnr.) Thus, for a benchmark suite of multiple apps, the time savings is not large -- the daemon was designed mainly to help trunaround time for interactive testing. But, including the daemon in the test suite gives us a mechanism to test and maintain it going forward.

Below are actual comparisons for 4-hour "daily" and 2-hour "pr" regression suites, with and without using the daemon.

### "Daily" regression suite
Comparing times (in seconds) for some of the dense apps in the "daily" suite.

BEFORE/daily: `onyx integration tests` step takes 3h 47m
https://buildkite.com/stanford-aha/aha-flow/builds/9602

```
step                         total    compile       map       test
---------------------------- -----  ---------  --------  ---------
apps/gaussian_glb              427        165        207        53
apps/pointwise_glb             301         67        197        36
apps/unsharp_glb               584        160        222       200
apps/camera_pipeline_2x2_glb  1200        337        368       494
apps/harris_color_glb          487        179        222        85
apps/cascade_glb               304         68        195        41
apps/maxpooling_glb           2616        305       1122      1188
```

AFTER/daily: `onyx integration tests` step takes 3h 40m
https://buildkite.com/stanford-aha/aha-flow/builds/9632
```
apps/gaussian_glb              477        174        249        53
apps/pointwise_glb             200         69         91        39
apps/unsharp_glb               523        164        126       232
apps/camera_pipeline_2x2_glb  1147        350        272       524
apps/harris_color_glb          409        188        131        89
apps/cascade_glb               222         73        105        42
apps/maxpooling_glb           2706        318       1068      1319
```

Comparing "map" times, we see that daemon saves about 90 seconds from each dense app:
```
                                D     No D     diff
apps/gaussian_glb             207      249      +41
apps/pointwise_glb            197       91     -105
apps/unsharp_glb              222      126      -96
apps/camera_pipeline_2x2_glb  368      272      -96
apps/harris_color_glb         222      131      -91
apps/cascade_glb              195      105      -89
apps/maxpooling_glb          1122     1068      -53
```
### "PR" regression suite
Similarly, we can compare times (in seconds) for the 'pr' regression suite.

BEFORE/pr: `onyx integration tests` step takes 1h 40m
https://buildkite.com/stanford-aha/aha-flow/builds/9604

AFTER/pr `onyx integration tests` step takes 1h 25m
https://buildkite.com/stanford-aha/aha-flow/builds/9676

The pr suite contains eleven dense apps, so we expect about 15 minutes' saving, which is what we got.
