### PR TITLE
replace include-sparse flag so that by default we are generating sparse+dense hardware

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -210,7 +210,7 @@ steps:
     else
       echo "Trigger came from aha repo; use default config";
     fi;
-  - aha regress $$CONFIG --daemon auto
+  - aha regress $$CONFIG --daemon auto --include-dense-only-tests
   # We report success to the aha-flow app by removing the .TEST file,
   # which is created in the post-checkout hook and checked for in the
   # pre-exit hook.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         docker run --name test --rm -it -d testing bash
         docker exec test pip freeze
-        docker exec test bash -c "source /aha/bin/activate && aha garnet --width 4 --height 2 --verilog --use_sim_sram --include-sparse"
+        docker exec test bash -c "source /aha/bin/activate && aha garnet --width 4 --height 2 --verilog --use_sim_sram"
         docker exec test test -e /aha/garnet/garnet.v
     - name: Notify Owners on Failure
       if: github.event_name == 'pull_request' && failure()

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -16,7 +16,7 @@ def add_subparser(subparser):
     parser = subparser.add_parser(Path(__file__).stem, add_help=False)
     parser.add_argument("config")
     parser.add_argument("--env-parameters", default="", type=str)
-    parser.add_argument("--test-dense-only", action="store_true")
+    parser.add_argument("--include-dense-only-tests", action="store_true")
     parser.set_defaults(dispatch=dispatch)
 
 
@@ -588,7 +588,7 @@ def dispatch(args, extra_args=None):
                                     width, height, args.env_parameters, extra_args)
         info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2])
 
-    if args.test_dense_only:
+    if args.include_dense_only_tests:
         # DENSE ONLY TESTS
         # Remove sparse+dense garnet.v first 
         exit_status = os.system(f"rm /aha/garnet/garnet.v")

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -16,6 +16,7 @@ def add_subparser(subparser):
     parser = subparser.add_parser(Path(__file__).stem, add_help=False)
     parser.add_argument("config")
     parser.add_argument("--env-parameters", default="", type=str)
+    parser.add_argument("--test-dense-only", action="store_true")
     parser.set_defaults(dispatch=dispatch)
 
 
@@ -42,43 +43,30 @@ def buildkite_call(command, env={}, return_output=False, out_file=None):
     )
 
 
-def gen_garnet(width, height, include_sparse=True):
+def gen_garnet(width, height, dense_only=False):
     print("--- Generating Garnet", flush=True)
     start = time.time()
     if not os.path.exists("/aha/garnet/garnet.v"):
-
         # Daemon is no good if/when we build new/different verilog
         buildkite_call("aha garnet --daemon kill".split())
         
         # No garnet verilog yet, so build it now.
 
-        if include_sparse:
-            print("---GENERATING SPARSE+DENSE CGRA---")
-            buildkite_call(
-                [
-                    "aha",
-                    "garnet",
-                    "--width", str(width),
-                    "--height", str(height),
-                    "--verilog",
-                    "--use_sim_sram",
-                    "--include-sparse",
-                    "--glb_tile_mem_size", str(128),
-                ]
-            )
-        else:
-            print("---GENERATING DENSE-ONLY CGRA---")
-            buildkite_call(
-                [
-                    "aha",
-                    "garnet",
-                    "--width", str(width),
-                    "--height", str(height),
-                    "--verilog",
-                    "--use_sim_sram",
-                    "--glb_tile_mem_size", str(128),
-                ]
-            )
+        buildkite_args = [
+                            "aha",
+                            "garnet",
+                            "--width", str(width),
+                            "--height", str(height),
+                            "--verilog",
+                            "--use_sim_sram",
+                            "--glb_tile_mem_size", str(128),
+                         ]
+
+        if dense_only:
+            buildkite_args.append("--dense-only")
+
+        buildkite_call(buildkite_args)
+        
     return time.time() - start
 
 
@@ -209,7 +197,7 @@ def test_sparse_app(testname, seed_flow, suitesparse_data_tile_pairs, test=""):
     return 0, 0, time_test
 
 
-def test_dense_app(test, width, height, env_parameters, extra_args, layer=None, include_sparse=True):
+def test_dense_app(test, width, height, env_parameters, extra_args, layer=None, dense_only=False):
     env_parameters = str(env_parameters)
     testname = layer if layer is not None else test
     print(f"--- {testname}")
@@ -241,29 +229,19 @@ def test_dense_app(test, width, height, env_parameters, extra_args, layer=None, 
         if ('--daemon' in extra_args) and ('auto' in extra_args):
             use_daemon = [ "--daemon", "auto" ]
 
-    if include_sparse:
-        buildkite_call(
-            [
-                "aha",
-                "pnr",
-                test,
-                "--width", str(width),
-                "--height", str(height),
-                "--include-sparse",
-                "--env-parameters", env_parameters,
-            ] + use_daemon + layer_array
-        )
-    else:
-        buildkite_call(
-            [
-                "aha",
-                "pnr",
-                test,
-                "--width", str(width),
-                "--height", str(height),
-                "--env-parameters", env_parameters,
-            ] + use_daemon + layer_array
-        )
+    buildkite_args = [
+            "aha",
+            "pnr",
+            test,
+            "--width", str(width),
+            "--height", str(height),
+            "--env-parameters", env_parameters,
+        ] + use_daemon + layer_array
+
+    if dense_only:
+        buildkite_args.append("--dense-only")
+    
+    buildkite_call(buildkite_args)
 
     time_map = time.time() - start
 
@@ -275,7 +253,7 @@ def test_dense_app(test, width, height, env_parameters, extra_args, layer=None, 
     return time_compile, time_map, time_test
 
 
-def test_hardcoded_dense_app(test, width, height, env_parameters, extra_args, layer=None, include_sparse=True):
+def test_hardcoded_dense_app(test, width, height, env_parameters, extra_args, layer=None, dense_only=False):
     env_parameters = str(env_parameters)
     testname = layer if layer is not None else test
     print(f"--- {testname}")
@@ -311,22 +289,7 @@ def test_hardcoded_dense_app(test, width, height, env_parameters, extra_args, la
         if ('--daemon' in extra_args) and ('auto' in extra_args):
             use_daemon = [ "--daemon", "auto" ]
 
-    if include_sparse:
-        buildkite_call(
-            [
-                "aha",
-                "pnr",
-                test,
-                "--width", str(width),
-                "--height", str(height),
-                "--include-sparse",
-                "--generate-bitstream-only",
-                "--env-parameters", env_parameters,
-            ] + use_daemon + layer_array
-        )
-    else:
-        buildkite_call(
-            [
+    buildkite_args = [
                 "aha",
                 "pnr",
                 test,
@@ -335,7 +298,12 @@ def test_hardcoded_dense_app(test, width, height, env_parameters, extra_args, la
                 "--generate-bitstream-only",
                 "--env-parameters", env_parameters,
             ] + use_daemon + layer_array
-        )
+
+    if dense_only:
+        buildkite_args.append("--dense-only")
+
+    buildkite_call(buildkite_args)
+
     time_map = time.time() - start
 
     print(f"--- {testname} - glb testing", flush=True)
@@ -561,7 +529,7 @@ def dispatch(args, extra_args=None):
 
     print(f"--- Running regression: {args.config}", flush=True)
     info = []
-    t = gen_garnet(width, height, include_sparse=True)
+    t = gen_garnet(width, height, dense_only=False)
     info.append(["garnet with sparse and dense", t])
 
     suitesparse_data_tile_pairs = []
@@ -620,30 +588,30 @@ def dispatch(args, extra_args=None):
                                     width, height, args.env_parameters, extra_args)
         info.append([test + "_glb", t0 + t1 + t2, t0, t1, t2])
 
+    if args.test_dense_only:
+        # DENSE ONLY TESTS
+        # Remove sparse+dense garnet.v first 
+        exit_status = os.system(f"rm /aha/garnet/garnet.v")
+        if os.WEXITSTATUS(exit_status) != 0:
+            raise RuntimeError(f"Command 'rm /aha/garnet/garnet.v' returned non-zero exit status {os.WEXITSTATUS(exit_status)}.")
+        
+        t = gen_garnet(width, height, dense_only=True)
+        info.append(["garnet with dense only", t])
 
-    # DENSE ONLY TESTS
-    # Remove sparse+dense garnet.v first 
-    exit_status = os.system(f"rm /aha/garnet/garnet.v")
-    if os.WEXITSTATUS(exit_status) != 0:
-        raise RuntimeError(f"Command 'rm /aha/garnet/garnet.v' returned non-zero exit status {os.WEXITSTATUS(exit_status)}.")
-    
-    t = gen_garnet(width, height, include_sparse=False)
-    info.append(["garnet with dense only", t])
-
-    num_dense_only_glb_tests = 5
-    for test_index, test in enumerate(glb_tests):
-        if test_index == num_dense_only_glb_tests:
-            break
-        t0, t1, t2 = test_dense_app(test, 
-                                    width, height, args.env_parameters, extra_args, include_sparse=False)
-        info.append([test + "_glb dense only", t0 + t1 + t2, t0, t1, t2])
-
-    for test in resnet_tests:
-        # residual resnet test is not working with dense only mode
-        if "residual" not in test:
-            t0, t1, t2 = test_dense_app("apps/resnet_output_stationary",
-                                        width, height, args.env_parameters, extra_args, layer=test)
+        num_dense_only_glb_tests = 5
+        for test_index, test in enumerate(glb_tests):
+            if test_index == num_dense_only_glb_tests:
+                break
+            t0, t1, t2 = test_dense_app(test, 
+                                        width, height, args.env_parameters, extra_args, dense_only=True)
             info.append([test + "_glb dense only", t0 + t1 + t2, t0, t1, t2])
+
+        for test in resnet_tests:
+            # residual resnet test is not working with dense only mode
+            if "residual" not in test:
+                t0, t1, t2 = test_dense_app("apps/resnet_output_stationary",
+                                            width, height, args.env_parameters, extra_args, layer=test)
+                info.append([test + "_glb dense only", t0 + t1 + t2, t0, t1, t2])
  
     print(f"+++ TIMING INFO", flush=True)
     print(tabulate(info, headers=["step", "total", "compile", "map", "test"]), flush=True)


### PR DESCRIPTION
Also, only enable the dense-only test in the regression if you use the --include-dense-only-tests flag on aha regress