### PR TITLE
Garnet-PR bypass for aha-flow pipeilne

### DIFF
--- a/.buildkite/bin/set-trigfrom-and-reqtype.sh
+++ b/.buildkite/bin/set-trigfrom-and-reqtype.sh
@@ -53,5 +53,7 @@ echo "--- FOUND REQUEST_TYPE '$REQUEST_TYPE'"
 temp=/var/lib/buildkite-agent/builds/DELETEME; mkdir -p $temp
 env=$temp/env-$BUILDKITE_BUILD_NUMBER
 echo REQUEST_TYPE=${REQUEST_TYPE} >> $env
+echo PR_REPO_TAIL=${PR_REPO_TAIL} >> $env
+set -x; cat $env; set +x
 
 echo "+++ set-trigfrom-and-reqtype.sh END"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -180,9 +180,10 @@ steps:
           if [ "$$REQUEST_TYPE" == "SUBMOD_PR" ]; then
               echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
               if [ "$$PR_REPO_TAIL" == "garnet" ]; then
-                  echo "+++ (TBD) Garnet PR detected, so skip redundant regressions (TBD)."
+                  # Delete .TEST as a sign to skip tests
+                  echo "+++ Garnet PR detected, so skip redundant regressions"
+                  rm -rf temp/.TEST
               fi
-              echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
           else
               echo "+++ UNSET DO_PR"; /bin/rm -rf temp/DO_PR
           fi
@@ -206,6 +207,11 @@ steps:
           ~/bin/status-update success
 
   commands:
+  - |
+    if ! test -e /buildkite/.TEST; then
+        echo "+++ No .TEST detected, so skip redundant regressions"
+        exit
+    fi
   - |
     if test -e /buildkite/DO_PR; then
         echo "--- DO_PR SET (TRUE)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,7 +41,7 @@ steps:
 
         echo "+++ TEMPORARY HACK FOR TESTING PURPOSES"
         set -x
-        git fetch origin; git checkout origin/aha-flow-garnet-pr-bypass
+        git pull; git checkout aha-flow-garnet-pr-bypass
         set +x
         echo "--- Continue..."
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,6 +36,20 @@ steps:
         git clean -ffxdq
         set +x
 
+
+
+
+        echo "+++ TEMPORARY HACK FOR TESTING PURPOSES"
+        set -x
+        git fetch origin; git checkout origin/aha-flow-garnet-pr-bypass
+        set +x
+        echo "--- Continue..."
+
+
+
+
+
+
         bin=$BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/bin
 
         # Make sure env var BUILDKITE_PULL_REQUEST_REPO is set correctly
@@ -157,12 +171,19 @@ steps:
           # THIS ASSUMES THAT ALL STEPS RUN ON SAME HOST MACHINE and thus see the same commdir!
 
           # env file sets REQUEST_TYPE to one of "AHA_PUSH", "AHA_PR", or "SUBMOD_PR"
+          # also sets "PR_TAIL_REPO" to requesting submod e.g. "garnet"
+          set -x; cat /var/lib/buildkite-agent/builds/DELETEME/env-$$BUILDKITE_BUILD_NUMBER; set +x
           source /var/lib/buildkite-agent/builds/DELETEME/env-$$BUILDKITE_BUILD_NUMBER
 
           echo "--- Pass DO_PR info to docker"
           echo "Info gets passed to docker by mounting temp dir as /buildkite omg omg"
           if [ "$$REQUEST_TYPE" == "SUBMOD_PR" ]; then
-              echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
+              if [ "$$PR_REPO_TAIL" == "garnet" ]; then
+                  echo "+++ Garnet PR detected, so skip redundant regressions."
+                  exit
+              else
+                  echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
+              fi
           else
               echo "+++ UNSET DO_PR"; /bin/rm -rf temp/DO_PR
           fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -178,15 +178,20 @@ steps:
           echo "--- Pass DO_PR info to docker"
           echo "Info gets passed to docker by mounting temp dir as /buildkite omg omg"
           if [ "$$REQUEST_TYPE" == "SUBMOD_PR" ]; then
-              if [ "$$PR_REPO_TAIL" == "garnet" ]; then
-                  echo "+++ Garnet PR detected, so skip redundant regressions."
-                  set -x
-                  rm -rf temp/.TEST
-                  buildkite-agent step update "commands" "exit"
-                  set +x
-              else
-                  echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
-              fi
+
+              echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
+
+
+#               if [ "$$PR_REPO_TAIL" == "garnet" ]; then
+#                   echo "+++ Garnet PR detected, so skip redundant regressions."
+#                   set -x
+#                   rm -rf temp/.TEST
+#                   buildkite-agent step update "commands" "exit"
+#                   set +x
+#               else
+#                   echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
+#               fi
+
           else
               echo "+++ UNSET DO_PR"; /bin/rm -rf temp/DO_PR
           fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,21 +35,6 @@ steps:
         git remote set-url origin https://github.com/StanfordAHA/aha     # Why?
         git clean -ffxdq
         set +x
-
-
-
-
-        echo "+++ TEMPORARY HACK FOR TESTING PURPOSES"
-        set -x
-        git pull; git checkout aha-flow-garnet-pr-bypass
-        set +x
-        echo "--- Continue..."
-
-
-
-
-
-
         bin=$BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/bin
 
         # Make sure env var BUILDKITE_PULL_REQUEST_REPO is set correctly

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -178,20 +178,11 @@ steps:
           echo "--- Pass DO_PR info to docker"
           echo "Info gets passed to docker by mounting temp dir as /buildkite omg omg"
           if [ "$$REQUEST_TYPE" == "SUBMOD_PR" ]; then
-
               echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
-
-
-#               if [ "$$PR_REPO_TAIL" == "garnet" ]; then
-#                   echo "+++ Garnet PR detected, so skip redundant regressions."
-#                   set -x
-#                   rm -rf temp/.TEST
-#                   buildkite-agent step update "commands" "exit"
-#                   set +x
-#               else
-#                   echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
-#               fi
-
+              if [ "$$PR_REPO_TAIL" == "garnet" ]; then
+                  echo "+++ (TBD) Garnet PR detected, so skip redundant regressions (TBD)."
+              fi
+              echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
           else
               echo "+++ UNSET DO_PR"; /bin/rm -rf temp/DO_PR
           fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -180,7 +180,10 @@ steps:
           if [ "$$REQUEST_TYPE" == "SUBMOD_PR" ]; then
               if [ "$$PR_REPO_TAIL" == "garnet" ]; then
                   echo "+++ Garnet PR detected, so skip redundant regressions."
-                  exit
+                  set -x
+                  rm -rf temp/.TEST
+                  buildkite-agent step update "commands" "exit"
+                  set +x
               else
                   echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
               fi


### PR DESCRIPTION
When the garnet repo has a pull request, it triggers both `aha-flow` and `garnet`  buildkite pipelines as CI tests. Previously, both pipelines ran a full set of identical `pr` regressions, taking 2.5 hours each, running (and needlessly compounding the load) on the same machine `r7cad-docker`.

The changes proposed in this pull prevent `pr` regressions from running on the `aha-flow` pipeline in the case where it is triggered by a Garnet-repo pull request.