### PR TITLE
Parallel regressions cleanup

### DIFF
--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -21,17 +21,20 @@ cd $BUILDKITE_BUILD_CHECKOUT_PATH
 if [ "$REQUEST_TYPE" == "SUBMOD_PR" ]; then
 
     # This script is called only from pipeline.yml BDI step (I think).
-    # BDI step is responsible for leaving us in default aha branch (e.g. master or dev)
+    # BDI step should have put us in default aha branch (e.g. master or dev)
     echo "Pull request from a submod repo: stay in aha master branch"
 
-    # Not sure why we need this. Keeping it for legacy reasons...
+    # Not sure why we need this 'git fetch' (below). Keeping it for legacy reasons...
+    # THIS DOES NOT CHECKOUT MASTER; e.g. if we were on DEV_BRANCH, we stay there...
     git fetch -v --prune -- origin master
 
 else
-    echo "Push or PR from aha repo: check out requested aha branch $BUILDKITE_COMMIT"
+    echo "Push or PR from aha repo: check out requested aha branch '$BUILDKITE_COMMIT'"
     git fetch -v --prune -- origin $BUILDKITE_COMMIT
     git checkout -qf $BUILDKITE_COMMIT
 fi
+echo DEV_BRANCH=$DEV_BRANCH || echo okay
+echo -n "DEV_BRANCH commit = "; git rev-parse $DEV_BRANCH || echo okay
 echo -n "Aha master commit = "; git rev-parse master
 echo -n "We now have commit: "; git rev-parse HEAD
 

--- a/.buildkite/bin/regress-metahooks.sh
+++ b/.buildkite/bin/regress-metahooks.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# This is where we offload meta-hook commands for pipeline.yml
+# These commands run OUTSIDE the docker container, that's why we use meta-hooks.
+
+if [ "$1" == '--pre-command' ]; then
+    echo "+++ OIT PRE COMMAND HOOK BEGIN"
+
+    # Use temp/.TEST to pass fail/success info into and out of docker container
+    echo Renewing `pwd`/temp/.TEST
+    mkdir -p temp; rm -rf temp/.TEST; touch temp/.TEST
+
+    # If trigger came from a submod repo, we will do "pr" regressions.
+    # Otherwise, trigger came from aha repo push/pull and we do (default) "aha_pr" regressions.
+    # We use "env" file to pass information between steps.
+    # THIS ASSUMES THAT ALL STEPS RUN ON SAME HOST MACHINE and thus see the same commdir!
+
+    # env file sets REQUEST_TYPE to one of "AHA_PUSH", "AHA_PR", or "SUBMOD_PR"
+    # also sets "PR_TAIL_REPO" to requesting submod e.g. "garnet"
+    echo cat /var/lib/buildkite-agent/builds/DELETEME/env-$BUILDKITE_BUILD_NUMBER
+    cat /var/lib/buildkite-agent/builds/DELETEME/env-$BUILDKITE_BUILD_NUMBER
+    source /var/lib/buildkite-agent/builds/DELETEME/env-$BUILDKITE_BUILD_NUMBER
+
+    echo "--- Pass DO_PR info to docker"
+    echo "Info gets passed to docker by mounting temp dir as /buildkite omg omg"
+    if [ "$REQUEST_TYPE" == "SUBMOD_PR" ]; then
+        echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
+        if [ "$PR_REPO_TAIL" == "garnet" ]; then
+            # Delete .TEST as a sign to skip tests
+            echo "+++ Garnet PR detected, so skip redundant regressions"
+            rm -rf temp/.TEST
+        fi
+    else
+        echo "+++ UNSET DO_PR"; /bin/rm -rf temp/DO_PR
+    fi
+    test -e temp/DO_PR && echo FOO temp/DO_PR exists || echo FOO temp/DO_PR not exists
+
+    echo "--- OIT PRE COMMAND HOOK END"
+
+elif [ "$1" == '--commands' ]; then
+
+    # These commands run INSIDE the docker container
+    # Also need to be sourced maybe?
+    # So maybe do something like...?
+    #    $0 --commands > tmp; source tmp
+
+    # cat <<'EOF' | sed "s/--BENCHMARK--/$2/"  # Single-quotes prevent var expansion etc.
+    cat <<'EOF'  # Single-quotes prevent var expansion etc.
+
+    if ! test -e /buildkite/.TEST; then
+        echo "+++ No .TEST detected, so skip redundant regressions"
+        exit
+    fi
+    test -e /buildkite/DO_PR && echo "--- DO_PR SET (TRUE)"
+    test -e /buildkite/DO_PR || echo "--- DO_PR UNSET (FALSE)"
+
+    source /aha/bin/activate
+    source /cad/modules/tcl/init/sh
+    module load base incisive xcelium/19.03.003 vcs/T-2022.06-SP2
+
+    # make /bin/sh symlink to bash instead of dash:
+    echo "dash dash/sh boolean false" | debconf-set-selections
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
+    # Install 'time' package (what? why?)
+    apt update
+    apt install time
+
+    echo    "--- PIP FREEZE"; pip freeze  # ??? okay? why? ???
+    echo    "+++ RUN REGRESSIONS"
+    echo -n "Garnet version "; (cd garnet && git rev-parse --verify HEAD)
+
+    # FIXME (below) this if-then-else jungle is awful; redo it!
+
+    DO_AR=True
+
+    # Prepare to run regression tests according to whether it's a submod PR
+    if test -e /buildkite/DO_PR; then
+      echo "Trigger came from submod repo pull request; use pr config"; export CONFIG=pr;
+      if [ "$REGSTEP" == 2 -o "$REGSTEP" == 3 ]; then
+        echo "oops no REGSTEP='$REGSTEP', not doing regressions"
+        DO_AR=False
+      fi
+
+    elif [ "$CONFIG" == "pr_aha" ]; then
+
+      # Normal
+      [ "$REGSTEP" == 1 ] && export CONFIG=pr_aha1
+      [ "$REGSTEP" == 2 ] && export CONFIG=pr_aha2
+      [ "$REGSTEP" == 3 ] && export CONFIG=pr_aha3
+
+      # Prototype
+      # [ "$REGSTEP" == 1 ] && export CONFIG=fast
+      # [ "$REGSTEP" == 2 ] && export CONFIG=fast
+      # [ "$REGSTEP" == 3 ] && export CONFIG=fast
+
+      echo "Trigger came from aha repo step '$REGSTEP'; use $CONFIG";
+
+    else
+      echo "Trigger came from OTHER, use default and/or config='$CONFIG'"
+      if [ "$REGSTEP" == 2 -o "$REGSTEP" == 3 ]; then
+        echo "oops no REGSTEP='$REGSTEP', not doing regressions"
+        DO_AR=False
+      fi
+    fi
+
+    if [ "$DO_AR" == "True" ]; then
+      # aha regress --BENCHMARK-- --include-dense-only-tests || exit 13  # Magic happens here...
+      # aha regress pr_aha1 --daemon auto --include-dense-only-tests || exit 13
+
+      # For fast prototyping: ECHO ONLY and/or try config 'fast'
+      set -x
+      echo "aha regress $CONFIG"
+      aha regress $CONFIG --daemon auto --include-dense-only-tests || exit 13
+      set +x
+    fi
+
+
+    # Remove .TEST to signal that benchmark completed successfully
+    # Okay to remove or check but DO NOT CREATE anything in /buildkite, it is owned by root :(
+    echo "--- Removing Failure Canary"; rm -rf /buildkite/.TEST
+
+EOF
+
+
+elif [ "$1" == '--pre-exit' ]; then
+
+    echo "+++ [pre-exit] KILL CONTAINER $CONTAINER"
+    set -x; docker kill $CONTAINER; set +x
+
+    echo "+++ [pre-exit] CHECKING EXIT STATUS"
+    echo "Send status to github."; set -x
+    cd $BUILDKITE_BUILD_CHECKOUT_PATH
+
+    # Docker will have removed temp/.TEST if all the tests passed
+    if [ "$BUILDKITE_COMMAND_EXIT_STATUS" == 0 ]; then
+        test -f temp/.TEST && export BUILDKITE_COMMAND_EXIT_STATUS=13
+    fi
+    /bin/rm -rf temp
+
+    # FIXME
+    # OMG! OH no you di'nt! ~/bin??? what are you THINKING
+    # Looks like ~/bin devolves to e.g. /var/lib/buildkite-agent/bin
+
+    # status-update will magically override "success" with "failure" as appropriate!
+    # (Based on BUILDKITE_COMMAND_EXIT_STATUS and BUILDKITE_LAST_HOOK_EXIT_STATUS)
+    ~/bin/status-update success
+
+fi
+

--- a/.buildkite/bin/update-pr-repo.sh
+++ b/.buildkite/bin/update-pr-repo.sh
@@ -13,6 +13,9 @@ cd $BUILDKITE_BUILD_CHECKOUT_PATH    # Just in case, I dunno, whatevs.
 
 # Also need to rediscover pull number BUILDKITE_PULL_REQUEST
 
+# This script is sourced only from pipeline.yml
+# and only when AHA_SUBMOD_FLOW_COMMIT exists i.e.:
+# [ "$$AHA_SUBMOD_FLOW_COMMIT" ] && source $$bin/update-pr-repo.sh
 
 echo "- Reset BUILDKITE_COMMIT according to env var set by aha-submod-flow steps :("
 echo "- https://buildkite.com/stanford-aha/aha-submod-flow/settings/steps"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,9 @@ env:
   IMAGE: garnet:aha-flow-build-$BUILDKITE_BUILD_NUMBER
 
 steps:
+
 - label: "Build Docker Image"
+
   plugins:
   # Override standard checkout procedure with custom checkout script
   - uber-workflow/run-without-clone:
@@ -52,6 +54,7 @@ steps:
             git checkout $$BUILDKITE_COMMIT
         fi
 
+
         # If build was triggered by a pull request, annotate build with
         #    links pointing to pull request on github.
         # Set REQUEST_TYPE to one of "AHA_PUSH", "AHA_PR", or "SUBMOD_PR"
@@ -78,11 +81,15 @@ steps:
   commands:
   - echo "+++ BDI PIPELINE.XML COMMANDS BEGIN"
 
+  - echo "--- Save repo things in common area"
+  - mkdir -p $$COMMON
+  - cp $$BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/bin/regress-metahooks.sh $$COMMON
+
   - echo "--- DEBUG DOCKER TRASH"
   - set -x; docker images; docker ps;
 
   - echo "--- Creating garnet Image"
-  - docker build . -t "garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}"
+  - docker build . -t "$$IMAGE"
 
   - echo "--- Pruning Docker Images"
   - yes | docker image prune -a --filter "until=6h" --filter=label='description=garnet' || true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -119,9 +119,18 @@ steps:
         exit 13
     fi
 
-- label: "Onyx Gold RTL 1m"
-  # Set soft_fail so that failing gold check does not fail pipeline.
-  soft_fail: true
+########################################################################
+# ONYX GOLD step
+
+- label: "Onyx Gold"
+  soft_fail: true  # So that failing gold check does not fail pipeline.
+  plugins:
+    - uber-workflow/run-without-clone:  # Don't need clone when using docker
+    - docker#v3.2.0:
+        image: garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}
+        volumes: ["/cad/:/cad"]
+        shell:   ["/bin/bash", "-e", "-c"]
+        mount-checkout: false
   commands: |
     echo "/aha/.buildkite/bin/rtl-goldcheck.sh onyx"
     if ! /aha/.buildkite/bin/rtl-goldcheck.sh onyx; then
@@ -130,14 +139,10 @@ steps:
         echo "$$msg" | buildkite-agent annotate --style "error" --context onyx
         exit 13
     fi
-  plugins:
-    - uber-workflow/run-without-clone:
-    - docker#v3.2.0:
-        image: garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}
-        volumes:
-          - "/cad/:/cad"
-        mount-checkout: false
-        shell: ["/bin/bash", "-e", "-c"]
+
+
+
+
 
 - label: "Onyx Integration Tests"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -170,119 +170,28 @@ steps:
     - docker exec -e CONFIG=$$CONFIG -e REGSTEP=1 $$CONTAINER /bin/bash -c "$$script"
     - docker kill $$CONTAINER
 
-
-
-
+########################################################################
+# STEP: onyx regression 2
 
 - label: "Regress 2"
+  env: { CONTAINER: deleteme-regress2-$BUILDKITE_BUILD_NUMBER }
 
   plugins:
     - uber-workflow/run-without-clone:
-    - docker#v3.2.0:
-        image: garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}
-        volumes:
-          - "/cad/:/cad"
-          - "./temp:/buildkite:rw"
-        mount-checkout: false
-        skip-checkout: true
-        propagate-environment: true
-        environment:
-          - CONFIG
-          - FLOW_REPO
-        shell: ["/bin/bash", "-e", "-c"]
     - improbable-eng/metahook:
-
-        pre-command: |
-          echo "+++ OIT PRE COMMAND HOOK BEGIN"
-
-          # Use temp/.TEST to pass fail/success info into and out of docker container
-          echo Renewing `pwd`/temp/.TEST
-          mkdir -p temp; rm -rf temp/.TEST; touch temp/.TEST
-
-          # If trigger came from a submod repo, we will do "pr" regressions.
-          # Otherwise, trigger came from aha repo push/pull and we just do "aha_pr" regressions.
-          # We use "env" file to pass information between steps.
-          # THIS ASSUMES THAT ALL STEPS RUN ON SAME HOST MACHINE and thus see the same commdir!
-
-          # env file sets REQUEST_TYPE to one of "AHA_PUSH", "AHA_PR", or "SUBMOD_PR"
-          # also sets "PR_TAIL_REPO" to requesting submod e.g. "garnet"
-          set -x; cat /var/lib/buildkite-agent/builds/DELETEME/env-$$BUILDKITE_BUILD_NUMBER; set +x
-          source /var/lib/buildkite-agent/builds/DELETEME/env-$$BUILDKITE_BUILD_NUMBER
-
-          echo "--- Pass DO_PR info to docker"
-          echo "Info gets passed to docker by mounting temp dir as /buildkite omg omg"
-          if [ "$$REQUEST_TYPE" == "SUBMOD_PR" ]; then
-              echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
-              if [ "$$PR_REPO_TAIL" == "garnet" ]; then
-                  # Delete .TEST as a sign to skip tests
-                  echo "+++ Garnet PR detected, so skip redundant regressions"
-                  rm -rf temp/.TEST
-              fi
-          else
-              echo "+++ UNSET DO_PR"; /bin/rm -rf temp/DO_PR
-          fi
-          test -e temp/DO_PR && echo FOO temp/DO_PR exists || echo FOO temp/DO_PR not exists
-
-          echo "--- OIT PRE COMMAND HOOK END"
-
-        pre-exit: |
-          echo "+++ CHECKING EXIT STATUS"; set -x
-          echo "Send status to github."
-          cd $$BUILDKITE_BUILD_CHECKOUT_PATH
-
-          # Docker will have removed temp/.TEST if all the tests passed
-          if [ "$$BUILDKITE_COMMAND_EXIT_STATUS" == 0 ]; then
-              test -f temp/.TEST && export BUILDKITE_COMMAND_EXIT_STATUS=13
-          fi
-          /bin/rm -rf temp
-
-          # status-update will magically override "success" with "failure" as appropriate!
-          # (Based on BUILDKITE_COMMAND_EXIT_STATUS and BUILDKITE_LAST_HOOK_EXIT_STATUS)
-          ~/bin/status-update success
+        pre-command: $REGRESS_METAHOOKS --pre-command
+        pre-exit:    $REGRESS_METAHOOKS --pre-exit
 
   commands:
-  - |
-    if ! test -e /buildkite/.TEST; then
-        echo "+++ No .TEST detected, so skip redundant regressions"
-        exit
-    fi
-  - |
-    if test -e /buildkite/DO_PR; then
-        echo "--- DO_PR SET (TRUE)"
-    else
-        echo "--- DO_PR UNSET (FALSE)"
-    fi
-  - source /aha/bin/activate
-  - source /cad/modules/tcl/init/sh
-  - module load base incisive xcelium/19.03.003 vcs/T-2022.06-SP2
-  # make /bin/sh symlink to bash instead of dash:
-  - echo "dash dash/sh boolean false" | debconf-set-selections
-  - DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
-  - apt update
-  - apt install time
-  - ls /aha
-  - echo    "--- PIP FREEZE"; pip freeze
-  - echo -n "--- GARNET VERSION "; (cd garnet && git rev-parse --verify HEAD)
-  # Run regression tests
-  - if test -e /buildkite/DO_PR; then
-      echo "Trigger is not from aha repo; so we don't do this test (yet)";
-    elif [ "$$CONFIG" == "aha_pr" ]; then
-      export CONFIG=pr_aha2;
-      echo "Trigger came from aha repo; use pr_aha2";
-      set -x; aha regress pr_aha2 --daemon auto --include-dense-only-tests || exit 13;
-    else
-      echo "Trigger is not from aha repo; so we don't do this test (yet)";
-    fi;
-  # - aha regress $$CONFIG --daemon auto --include-dense-only-tests
+    - docker kill $$CONTAINER || echo okay
+    - docker run -id --name $$CONTAINER --rm -v /cad:/cad -v ./temp:/buildkite:rw $$IMAGE bash
+    - script="$($REGRESS_METAHOOKS --commands)"
+    - docker exec -e CONFIG=$$CONFIG -e REGSTEP=2 $$CONTAINER /bin/bash -c "$$script"
+    - docker kill $$CONTAINER
 
-  # We report success to the aha-flow app by removing the .TEST file,
-  # which is created in the post-checkout hook and checked for in the pre-exit hook.
 
-  # Okay to remove or check but DO NOT CREATE anything in /buildkite, it is owned by root :(
-  - echo "--- Removing Failure Canary"
-  - ls -al /buildkite
-  - rm -rf /buildkite/.TEST
-  - ls -al /buildkite
+
+
 
 
 - label: "Regress 3"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -98,9 +98,18 @@ steps:
 
 - wait: ~
 
-- label: "Amber Gold RTL 1m"
-  # Set soft_fail so that failing gold check does not fail pipeline.
-  soft_fail: true
+########################################################################
+# AMBER GOLD step
+
+- label: "Amber Gold RTL"
+  soft_fail: true  # So that failing gold check does not fail pipeline.
+  plugins:
+    - uber-workflow/run-without-clone:  # Don't need clone when using docker
+    - docker#v3.2.0:
+        image: garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}
+        volumes: ["/cad/:/cad"]
+        shell:   ["/bin/bash", "-e", "-c"]
+        mount-checkout: false
   commands: |
     echo "/aha/.buildkite/bin/rtl-goldcheck.sh amber"
     if ! /aha/.buildkite/bin/rtl-goldcheck.sh amber; then
@@ -109,14 +118,6 @@ steps:
         echo "$$msg" | buildkite-agent annotate --style "error" --context amber
         exit 13
     fi
-  plugins:
-    - uber-workflow/run-without-clone:
-    - docker#v3.2.0:
-        image: garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}
-        volumes:
-          - "/cad/:/cad"
-        mount-checkout: false
-        shell: ["/bin/bash", "-e", "-c"]
 
 - label: "Onyx Gold RTL 1m"
   # Set soft_fail so that failing gold check does not fail pipeline.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,6 @@ env:
   IMAGE: garnet:aha-flow-build-$BUILDKITE_BUILD_NUMBER
 
 steps:
-
 - label: "Build Docker Image"
   plugins:
   # Override standard checkout procedure with custom checkout script
@@ -29,9 +28,6 @@ steps:
         echo "+++ BDI PRE CHECKOUT HOOK"
         set +u     # nounset? not on my watch!
 
-        if [ "$$FLOW_HEAD_SHA" ]; then
-            echo "+++ ERROR Not processing heroku requests anymore"; exit 13; fi
-
         # Clone the aha repo; starting in root dir '/' I think
         echo I am in dir `pwd`
         aha_clone=$BUILDKITE_BUILD_CHECKOUT_PATH;
@@ -43,12 +39,18 @@ steps:
         set +x
         bin=$BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/bin
 
-        # (aha-flow steps is responsible for setting DEV_BRANCH)
-        # (https://buildkite.com/stanford-aha/aha-flow/settings/steps)
-        git checkout $$DEV_BRANCH || echo no dev branch found, continuing with master
+        if [ "$$AHA_SUBMOD_FLOW_COMMIT" ]; then
+            echo 'Submod pull requests use master branch (sometimes overridden by DEV_BRANCH)'
+            # (aha-flow steps is responsible for setting DEV_BRANCH)
+            # (https://buildkite.com/stanford-aha/aha-flow/settings/steps)
+            git checkout $$DEV_BRANCH || echo no dev branch found, continuing with master
 
-        # Make sure env var BUILDKITE_PULL_REQUEST_REPO is set correctly
-        source $$bin/update-pr-repo.sh
+            # Make sure env var BUILDKITE_PULL_REQUEST_REPO is set correctly
+            source $$bin/update-pr-repo.sh
+        else
+            echo 'Aha push/PR uses pushed branch'
+            git checkout $$BUILDKITE_COMMIT
+        fi
 
         # If build was triggered by a pull request, annotate build with
         #    links pointing to pull request on github.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -208,22 +208,21 @@ steps:
     - docker exec -e CONFIG=$$CONFIG -e REGSTEP=3 $$CONTAINER /bin/bash -c "$$script"
     - docker kill $$CONTAINER
 
+########################################################################
+# STEP: final cleanup
 
-
-
-
-
-
-
-
-
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
+# Wait for all steps to complete before deleting image
+- wait: { continue_on_failure: true }
 
 - label: ":skull_and_crossbones: Delete Docker Image"
-  # Set soft_fail so that failing cleanup does not fail pipeline.
+
+  # "run-without-clone" b/c don't need repo just to delete the docker image
+  plugins:   [ uber-workflow/run-without-clone: ]
+
+  # Set "soft-fail" -- failing cleanup should not fail the larger pipeline.
   soft_fail: true
+
+  # Not exactly sure why '--no-prune' is included...?
   commands:
-  # '--no-prune' so it doesn't prune dangling images, we want to use them for the Docker cache.
-  - docker image rm "garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}" --no-prune
-  plugins:
-  - uber-workflow/run-without-clone:
+    - docker image rm "garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}" --no-prune
+    - /bin/rm -rf $$COMMON

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -189,120 +189,32 @@ steps:
     - docker exec -e CONFIG=$$CONFIG -e REGSTEP=2 $$CONTAINER /bin/bash -c "$$script"
     - docker kill $$CONTAINER
 
-
-
-
-
+########################################################################
+# STEP: onyx regression 3
 
 - label: "Regress 3"
+  env: { CONTAINER: deleteme-regress3-$BUILDKITE_BUILD_NUMBER }
 
   plugins:
     - uber-workflow/run-without-clone:
-    - docker#v3.2.0:
-        image: garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}
-        volumes:
-          - "/cad/:/cad"
-          - "./temp:/buildkite:rw"
-        mount-checkout: false
-        skip-checkout: true
-        propagate-environment: true
-        environment:
-          - CONFIG
-          - FLOW_REPO
-        shell: ["/bin/bash", "-e", "-c"]
     - improbable-eng/metahook:
-
-        pre-command: |
-          echo "+++ OIT PRE COMMAND HOOK BEGIN"
-
-          # Use temp/.TEST to pass fail/success info into and out of docker container
-          echo Renewing `pwd`/temp/.TEST
-          mkdir -p temp; rm -rf temp/.TEST; touch temp/.TEST
-
-          # If trigger came from a submod repo, we will do "pr" regressions.
-          # Otherwise, trigger came from aha repo push/pull and we just do "aha_pr" regressions.
-          # We use "env" file to pass information between steps.
-          # THIS ASSUMES THAT ALL STEPS RUN ON SAME HOST MACHINE and thus see the same commdir!
-
-          # env file sets REQUEST_TYPE to one of "AHA_PUSH", "AHA_PR", or "SUBMOD_PR"
-          # also sets "PR_TAIL_REPO" to requesting submod e.g. "garnet"
-          set -x; cat /var/lib/buildkite-agent/builds/DELETEME/env-$$BUILDKITE_BUILD_NUMBER; set +x
-          source /var/lib/buildkite-agent/builds/DELETEME/env-$$BUILDKITE_BUILD_NUMBER
-
-          echo "--- Pass DO_PR info to docker"
-          echo "Info gets passed to docker by mounting temp dir as /buildkite omg omg"
-          if [ "$$REQUEST_TYPE" == "SUBMOD_PR" ]; then
-              echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
-              if [ "$$PR_REPO_TAIL" == "garnet" ]; then
-                  # Delete .TEST as a sign to skip tests
-                  echo "+++ Garnet PR detected, so skip redundant regressions"
-                  rm -rf temp/.TEST
-              fi
-          else
-              echo "+++ UNSET DO_PR"; /bin/rm -rf temp/DO_PR
-          fi
-          test -e temp/DO_PR && echo FOO temp/DO_PR exists || echo FOO temp/DO_PR not exists
-
-          echo "--- OIT PRE COMMAND HOOK END"
-
-        pre-exit: |
-          echo "+++ CHECKING EXIT STATUS"; set -x
-          echo "Send status to github."
-          cd $$BUILDKITE_BUILD_CHECKOUT_PATH
-
-          # Docker will have removed temp/.TEST if all the tests passed
-          if [ "$$BUILDKITE_COMMAND_EXIT_STATUS" == 0 ]; then
-              test -f temp/.TEST && export BUILDKITE_COMMAND_EXIT_STATUS=13
-          fi
-          /bin/rm -rf temp
-
-          # status-update will magically override "success" with "failure" as appropriate!
-          # (Based on BUILDKITE_COMMAND_EXIT_STATUS and BUILDKITE_LAST_HOOK_EXIT_STATUS)
-          ~/bin/status-update success
+        pre-command: $REGRESS_METAHOOKS --pre-command
+        pre-exit:    $REGRESS_METAHOOKS --pre-exit
 
   commands:
-  - |
-    if ! test -e /buildkite/.TEST; then
-        echo "+++ No .TEST detected, so skip redundant regressions"
-        exit
-    fi
-  - |
-    if test -e /buildkite/DO_PR; then
-        echo "--- DO_PR SET (TRUE)"
-    else
-        echo "--- DO_PR UNSET (FALSE)"
-    fi
-  - source /aha/bin/activate
-  - source /cad/modules/tcl/init/sh
-  - module load base incisive xcelium/19.03.003 vcs/T-2022.06-SP2
-  # make /bin/sh symlink to bash instead of dash:
-  - echo "dash dash/sh boolean false" | debconf-set-selections
-  - DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
-  - apt update
-  - apt install time
-  - ls /aha
-  - echo    "--- PIP FREEZE"; pip freeze
-  - echo -n "--- GARNET VERSION "; (cd garnet && git rev-parse --verify HEAD)
-  # Run regression tests
-  - if test -e /buildkite/DO_PR; then
-      echo "Trigger is not from aha repo; so we don't do this test (yet)";
-    elif [ "$$CONFIG" == "aha_pr" ]; then
-      export CONFIG=pr_aha3;
-      echo "Trigger came from aha repo; use pr_aha3";
-      set -x; aha regress pr_aha3 --daemon auto --include-dense-only-tests || exit 13;
-    else
-      echo "Trigger is not from aha repo; so we don't do this test (yet)";
-    fi;
-  # - aha regress $$CONFIG --daemon auto --include-dense-only-tests
+    - docker kill $$CONTAINER || echo okay
+    - docker run -id --name $$CONTAINER --rm -v /cad:/cad -v ./temp:/buildkite:rw $$IMAGE bash
+    - script="$($REGRESS_METAHOOKS --commands)"
+    - docker exec -e CONFIG=$$CONFIG -e REGSTEP=3 $$CONTAINER /bin/bash -c "$$script"
+    - docker kill $$CONTAINER
 
-  # We report success to the aha-flow app by removing the .TEST file,
-  # which is created in the post-checkout hook and checked for in the pre-exit hook.
 
-  # Okay to remove or check but DO NOT CREATE anything in /buildkite, it is owned by root :(
-  - echo "--- Removing Failure Canary"
-  - ls -al /buildkite
-  - rm -rf /buildkite/.TEST
-  - ls -al /buildkite
+
+
+
+
+
+
 
 
 - wait: { continue_on_failure: true } # One step at a time + continue on failure

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,16 @@
-# To turn daemon on or off, search code below and change to one of:
-#   aha regress $$CONFIG --daemon auto  # Use daemon
-#   aha regress $$CONFIG                # No daemon
+# All "docker"-tagged agents must live on a single machine
+# (e.g. r7cad-docker), so they can all share the same docker image.
+agents: { docker: true }
 
 env:
-  # Default config is "aha_pr"
-  CONFIG: ${CONFIG:-aha_pr}
+  # Default config is "pr_aha"
+  CONFIG: ${CONFIG:-pr_aha}
+
+  # "COMMON" is a dir where we can pass information from one step to another
+  COMMON: /var/lib/buildkite-agent/builds/DELETEME-$BUILDKITE_BUILD_NUMBER
+
+  REGRESS_METAHOOKS: $$COMMON/regress-metahooks.sh
+  IMAGE: garnet:aha-flow-build-$BUILDKITE_BUILD_NUMBER
 
 steps:
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,6 @@ env:
 steps:
 
 - label: "Build Docker Image"
-  key: "docker-build"
   plugins:
   # Override standard checkout procedure with custom checkout script
   - uber-workflow/run-without-clone:
@@ -88,12 +87,9 @@ steps:
 
   - echo "--- BDI PIPELINE.XML COMMANDS END"
 
-  agents:
-    docker: true
+- wait: ~
 
 - label: "Amber Gold RTL 1m"
-  key: "goldcheck-amber"
-  depends_on: "docker-build"
   # Set soft_fail so that failing gold check does not fail pipeline.
   soft_fail: true
   commands: |
@@ -112,12 +108,8 @@ steps:
           - "/cad/:/cad"
         mount-checkout: false
         shell: ["/bin/bash", "-e", "-c"]
-  agents:
-    docker: true
 
 - label: "Onyx Gold RTL 1m"
-  key: "goldcheck-onyx"
-  depends_on: "docker-build"
   # Set soft_fail so that failing gold check does not fail pipeline.
   soft_fail: true
   commands: |
@@ -136,12 +128,8 @@ steps:
           - "/cad/:/cad"
         mount-checkout: false
         shell: ["/bin/bash", "-e", "-c"]
-  agents:
-    docker: true
 
 - label: "Onyx Integration Tests"
-  key: "integration-tests"
-  depends_on: "docker-build"
 
   plugins:
     - uber-workflow/run-without-clone:
@@ -252,12 +240,7 @@ steps:
   - rm -rf /buildkite/.TEST
   - ls -al /buildkite
 
-  agents:
-    docker: true
-
 - label: "Regress 2"
-  key: "integration-tests2"
-  depends_on: "docker-build"
 
   plugins:
     - uber-workflow/run-without-clone:
@@ -367,12 +350,8 @@ steps:
   - rm -rf /buildkite/.TEST
   - ls -al /buildkite
 
-  agents:
-    docker: true
 
 - label: "Regress 3"
-  key: "integration-tests3"
-  depends_on: "docker-build"
 
   plugins:
     - uber-workflow/run-without-clone:
@@ -482,24 +461,14 @@ steps:
   - rm -rf /buildkite/.TEST
   - ls -al /buildkite
 
-  agents:
-    docker: true
 
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 - label: ":skull_and_crossbones: Delete Docker Image"
   # Set soft_fail so that failing cleanup does not fail pipeline.
   soft_fail: true
-  depends_on:
-  - "integration-tests"
-  - "integration-tests2"
-  - "integration-tests3"
-  - "goldcheck-amber"
-  - "goldcheck-onyx"
   commands:
   # '--no-prune' so it doesn't prune dangling images, we want to use them for the Docker cache.
   - docker image rm "garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}" --no-prune
-  agents:
-    docker: true
   plugins:
   - uber-workflow/run-without-clone:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -140,120 +140,39 @@ steps:
         exit 13
     fi
 
+########################################################################
+# NOTES: onyx regressions
 
+# We report success to the aha-flow app by removing the .TEST file, which is
+# created in the post-checkout hook and checked-for in the pre-exit hook.
 
+# Instead of multiple similar onyx-regression steps, could maybe do
+# some kind of $$bin/gen-steps | docker-agent upload
 
+########################################################################
+# STEP: onyx regression 1
 
-- label: "Onyx Integration Tests"
+- label: "Regress 1"
+  env: { CONTAINER: deleteme-regress1-$BUILDKITE_BUILD_NUMBER }
 
   plugins:
     - uber-workflow/run-without-clone:
-    - docker#v3.2.0:
-        image: garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}
-        volumes:
-          - "/cad/:/cad"
-          - "./temp:/buildkite:rw"
-        mount-checkout: false
-        skip-checkout: true
-        propagate-environment: true
-        environment:
-          - CONFIG
-          - FLOW_REPO
-        shell: ["/bin/bash", "-e", "-c"]
+
     - improbable-eng/metahook:
-
-        pre-command: |
-          echo "+++ OIT PRE COMMAND HOOK BEGIN"
-
-          # Use temp/.TEST to pass fail/success info into and out of docker container
-          echo Renewing `pwd`/temp/.TEST
-          mkdir -p temp; rm -rf temp/.TEST; touch temp/.TEST
-
-          # If trigger came from a submod repo, we will do "pr" regressions.
-          # Otherwise, trigger came from aha repo push/pull and we do (default) "aha_pr" regressions.
-          # We use "env" file to pass information between steps.
-          # THIS ASSUMES THAT ALL STEPS RUN ON SAME HOST MACHINE and thus see the same commdir!
-
-          # env file sets REQUEST_TYPE to one of "AHA_PUSH", "AHA_PR", or "SUBMOD_PR"
-          # also sets "PR_TAIL_REPO" to requesting submod e.g. "garnet"
-          set -x; cat /var/lib/buildkite-agent/builds/DELETEME/env-$$BUILDKITE_BUILD_NUMBER; set +x
-          source /var/lib/buildkite-agent/builds/DELETEME/env-$$BUILDKITE_BUILD_NUMBER
-
-          echo "--- Pass DO_PR info to docker"
-          echo "Info gets passed to docker by mounting temp dir as /buildkite omg omg"
-          if [ "$$REQUEST_TYPE" == "SUBMOD_PR" ]; then
-              echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
-              if [ "$$PR_REPO_TAIL" == "garnet" ]; then
-                  # Delete .TEST as a sign to skip tests
-                  echo "+++ Garnet PR detected, so skip redundant regressions"
-                  rm -rf temp/.TEST
-              fi
-          else
-              echo "+++ UNSET DO_PR"; /bin/rm -rf temp/DO_PR
-          fi
-          test -e temp/DO_PR && echo FOO temp/DO_PR exists || echo FOO temp/DO_PR not exists
-
-          echo "--- OIT PRE COMMAND HOOK END"
-
-        pre-exit: |
-          echo "+++ CHECKING EXIT STATUS"; set -x
-          echo "Send status to github."
-          cd $$BUILDKITE_BUILD_CHECKOUT_PATH
-
-          # Docker will have removed temp/.TEST if all the tests passed
-          if [ "$$BUILDKITE_COMMAND_EXIT_STATUS" == 0 ]; then
-              test -f temp/.TEST && export BUILDKITE_COMMAND_EXIT_STATUS=13
-          fi
-          /bin/rm -rf temp
-
-          # status-update will magically override "success" with "failure" as appropriate!
-          # (Based on BUILDKITE_COMMAND_EXIT_STATUS and BUILDKITE_LAST_HOOK_EXIT_STATUS)
-          ~/bin/status-update success
+        pre-command: $REGRESS_METAHOOKS --pre-command
+        pre-exit:    $REGRESS_METAHOOKS --pre-exit
 
   commands:
-  - |
-    if ! test -e /buildkite/.TEST; then
-        echo "+++ No .TEST detected, so skip redundant regressions"
-        exit
-    fi
-  - |
-    if test -e /buildkite/DO_PR; then
-        echo "--- DO_PR SET (TRUE)"
-    else
-        echo "--- DO_PR UNSET (FALSE)"
-    fi
-  - source /aha/bin/activate
-  - source /cad/modules/tcl/init/sh
-  - module load base incisive xcelium/19.03.003 vcs/T-2022.06-SP2
-  # make /bin/sh symlink to bash instead of dash:
-  - echo "dash dash/sh boolean false" | debconf-set-selections
-  - DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
-  - apt update
-  - apt install time
-  - ls /aha
-  - echo    "--- PIP FREEZE"; pip freeze
-  - echo -n "--- GARNET VERSION "; (cd garnet && git rev-parse --verify HEAD)
-  # Run regression tests
-  - if test -e /buildkite/DO_PR; then
-      echo "Trigger came from submod repo pull request; use pr config";
-      export CONFIG=pr;
-    elif [ "$$CONFIG" == "aha_pr" ]; then
-      export CONFIG=pr_aha1;
-      echo "Trigger came from aha repo; use $$CONFIG";
-    else
-      echo "Trigger came from OTHER, use default and/or config=$$CONFIG";
-    fi;
-  - set -x; aha regress $$CONFIG --daemon auto --include-dense-only-tests
-  # - aha regress pr_aha1 --daemon auto --include-dense-only-tests || exit 13
+    - docker kill $$CONTAINER || echo okay
+    - docker run -id --name $$CONTAINER --rm -v /cad:/cad -v ./temp:/buildkite:rw $$IMAGE bash
+    - script="$($REGRESS_METAHOOKS --commands)"
+    # - docker exec -e CONFIG=fast -e REGSTEP=1 $$CONTAINER /bin/bash -c "$$script"
+    - docker exec -e CONFIG=$$CONFIG -e REGSTEP=1 $$CONTAINER /bin/bash -c "$$script"
+    - docker kill $$CONTAINER
 
-  # We report success to the aha-flow app by removing the .TEST file,
-  # which is created in the post-checkout hook and checked for in the pre-exit hook.
 
-  # Okay to remove or check but DO NOT CREATE anything in /buildkite, it is owned by root :(
-  - echo "--- Removing Failure Canary"
-  - ls -al /buildkite
-  - rm -rf /buildkite/.TEST
-  - ls -al /buildkite
+
+
 
 - label: "Regress 2"
 

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -388,263 +388,41 @@ def dispatch(args, extra_args=None):
     if args.config == "daily": args.config = "pr_aha"  # noqa
     if args.config == "pr": args.config = "pr_submod"  # noqa
 
-    if args.config == "fast":
-        width, height = 4, 4
-        sparse_tests = [
-            "vec_identity"
-        ]
-        glb_tests = [
-            "apps/pointwise"
-        ]
-        glb_tests_fp = [
-            "tests/fp_pointwise",
-        ]
-        resnet_tests = []
-        resnet_tests_fp = []
-        hardcoded_dense_tests = []
+    from aha.util.regress_tests.tests import Tests
+    imported_tests = None
 
-    elif args.config == "pr_aha1":  # For aha-repo push/pull
+    # pr_aha1,2,3 are 4-hour, 3-hour, and 3-hour slices of pr_aha, respectively
+    if args.config == "pr_aha1":
+        imported_tests = Tests("pr_aha")
+        imported_tests.resnet_tests.remove('conv2_x')  # This is actually *two* tests
+        imported_tests.resnet_tests_fp.remove('conv2_x_fp')
 
-        # aha pull requests used to invoke the much larger "daily"
-        # suite; which we deleted. Now, aha PRs invoke this pared-down
-        # test "pr_aha", (as recommended by Kalhan et al.).  Pr_aha is
-        # kind of an enhanced version of the old "pr" suite of tests,
-        # which was used by pull requests from AHA submodule repos.
-        # The old "pr" suite is now called "pr_submod". (Pr_submod
-        # only takes a couple of hours whereas pr_aha is in the 8-10
-        # hour range.)
+    # NOTE conv2 breaks if don't do gaussian first(!) for details see issues:
+    # https://github.com/StanfordAHA/garnet/issues/1070
+    # https://github.com/StanfordAHA/aha/issues/1897
+    elif args.config == "pr_aha2":
+        imported_tests = Tests("BLANK")
+        imported_tests.glb_tests = ["apps/gaussian"]
+        # Note conv2 here is actually *two* tests, one sparse and one dense
+        imported_tests.resnet_tests = [ 'conv2_x' ]
 
-        # 2. THEN we broke the 8-10 hour "pr_aha" test into three 3-hour
-        # tests pr_aha1,2,3 that can all run in parallel.
+    elif args.config == "pr_aha3":
+        imported_tests = Tests("BLANK")
+        imported_tests.glb_tests = ["apps/gaussian"]
+        imported_tests.resnet_tests_fp = [ 'conv2_x_fp' ]
 
-        width, height = 28, 16
-        sparse_tests = [
-            "vec_elemmul",
-            "mat_vecmul_ij",
-            "mat_elemadd_leakyrelu_exp",
-            "mat_elemdiv",
-            "mat_mattransmul",
-            "matmul_ijk_crddrop_relu",
-            "matmul_ikj",
-            "matmul_jik",
-            "spmm_ijk_crddrop_relu",
-            "spmv_relu",
-            "masked_broadcast",
-            "mat_sddmm",
-            "tensor3_mttkrp",
-            "tensor3_ttv",        
-        ]
-        glb_tests = [
-            "apps/pointwise",
-            "apps/gaussian",
-            "apps/camera_pipeline_2x2",
-        ]
-        glb_tests_fp = [
-            "apps/matrix_multiplication_fp",
-        ]
-        resnet_tests = [
-            "conv1",
-            "conv5_1",
-            "conv5_x",
-        ]
-        resnet_tests_fp = [
-        ]
-        hardcoded_dense_tests = [
-            "apps/depthwise_conv"
-        ]
-
-    elif args.config == "pr_aha2":  # For aha-repo push/pull
-        width, height = 28, 16
-        sparse_tests = []
-        glb_tests = ["apps/gaussian"]
-        glb_tests_fp = []
-        resnet_tests = ["conv2_x"]
-        resnet_tests_fp = []
-        hardcoded_dense_tests = []
-
-    elif args.config == "pr_aha3":  # For aha-repo push/pull
-        width, height = 28, 16
-        sparse_tests = []
-        glb_tests = ["apps/gaussian"]
-        glb_tests_fp = []
-        resnet_tests = []
-        resnet_tests_fp = ["conv2_x_fp"]
-        hardcoded_dense_tests = []
-
-    elif args.config == "pr_submod":  # For push/pull from aha submod repos
-
-        # This is the OLD / original two-hour submod pr, I think, from
-        # 611c8bb4, before I mucked things up...before that, this set
-        # of tests was called simply "pr"
-
-        width, height = 28, 16
-        sparse_tests = [
-            "vec_elemadd",
-            "vec_elemmul",
-            "vec_identity",
-            "vec_scalar_mul",
-            "mat_vecmul_ij",
-            "mat_elemadd",
-            "mat_elemadd_relu",
-            "matmul_ijk",
-            "matmul_ijk_crddrop",
-            "matmul_ijk_crddrop_relu",
-            # Turned off until SUB ordering fixed in mapping
-            # 'mat_residual',
-            "mat_vecmul_iter",
-            "tensor3_elemadd",
-            "tensor3_ttm",
-            "tensor3_ttv",
-        ]
-        glb_tests = [
-            "apps/pointwise",
-            "tests/ushift",
-            "tests/arith",
-            "tests/absolute",
-            "tests/scomp",
-            "tests/ucomp",
-            "tests/uminmax",
-            "tests/rom",
-            "tests/conv_1_2",
-            "tests/conv_2_1",
-        ]
-        glb_tests_fp = [
-            "tests/fp_pointwise",
-            "tests/fp_arith",
-            "tests/fp_comp",
-            "tests/fp_conv_7_7",
-        ]
-        resnet_tests = []
-        resnet_tests_fp = []
-        hardcoded_dense_tests = [
-            "apps/depthwise_conv"
-        ]
-
-    elif args.config == "full":
-        width, height = 28, 16
-        sparse_tests = [
-            "vec_elemadd",
-            "vec_elemmul",
-            "vec_identity",
-            "vec_scalar_mul",
-            "mat_vecmul_ij",
-            "mat_elemadd",
-            "mat_elemadd_relu",
-            "mat_elemadd_leakyrelu_exp",
-            "mat_elemadd3",
-            "mat_elemmul",
-            "mat_elemdiv",
-            "mat_identity",
-            "mat_mattransmul",
-            "matmul_ijk",
-            "matmul_ijk_crddrop",
-            "matmul_ijk_crddrop_relu",
-            "matmul_ikj",
-            "matmul_jik",
-            "spmm_ijk_crddrop",
-            "spmm_ijk_crddrop_relu",
-            "spmv",
-            "spmv_relu",
-            "masked_broadcast",
-            "trans_masked_broadcast",
-            "mat_dn2sp",
-            "mat_sp2dn",
-            # Turned off until SUB ordering fixed in mapping
-            # 'mat_residual',
-            "mat_sddmm",
-            "mat_mask_tri",
-            "mat_vecmul_iter",
-            "tensor3_elemadd",
-            "tensor3_elemmul",
-            "tensor3_identity",
-            "tensor3_innerprod",
-            "tensor3_mttkrp",
-            "tensor3_mttkrp_unfused1",
-            "tensor3_mttkrp_unfused2",
-            "tensor3_ttm",
-            "tensor3_ttv",
-
-        ]
-        glb_tests = [
-            "apps/pointwise",
-            "tests/rom",
-            "tests/arith",
-            "tests/absolute",
-            "tests/boolean_ops",
-            "tests/equal",
-            "tests/ternary",
-            "tests/scomp",
-            "tests/ucomp",
-            "tests/sminmax",
-            "tests/uminmax",
-            "tests/sshift",
-            "tests/ushift",
-            "tests/conv_1_2",
-            "tests/conv_2_1",
-            "tests/conv_3_3",
-            "apps/gaussian",
-            "apps/brighten_and_blur",
-            "apps/cascade",
-            "apps/harris",
-            "apps/resnet_layer_gen",
-            "apps/unsharp",
-            "apps/harris_color",
-            "apps/camera_pipeline_2x2",
-            "apps/maxpooling",
-            "apps/matrix_multiplication"
-        ]
-        glb_tests_fp = [
-            "tests/fp_pointwise",
-            "tests/fp_arith",
-            "tests/fp_comp",
-            "tests/fp_conv_7_7",
-            "apps/maxpooling_fp",
-            "apps/matrix_multiplication_fp",
-            "apps/mcunet_in_sequential_0_fp",
-        ]
-        resnet_tests = [
-            "conv1",
-            "conv2_x",
-            "conv3_1",
-            "conv3_x",
-            "conv4_1",
-            "conv4_x",
-            "conv5_1",
-            "conv5_x",
-            "conv2_x_residual",
-            "conv5_x_residual",
-        ]
-        resnet_tests_fp = [
-            "conv2_x_fp"
-        ]
-        hardcoded_dense_tests = [
-            "apps/depthwise_conv"
-        ]
-    elif args.config == "resnet":
-        width, height = 28, 16
-        sparse_tests = []
-        glb_tests = []
-        glb_tests_fp = []
-        resnet_tests = [
-            "conv1",
-            "conv2_x",
-            "conv3_1",
-            "conv3_x",
-            "conv4_1",
-            "conv4_x",
-            "conv5_1",
-            "conv5_x",
-            "conv2_x_residual",
-            "conv3_x_residual",
-            "conv4_x_residual",
-            "conv5_x_residual",
-        ]
-        resnet_tests_fp = []
-        hardcoded_dense_tests = []
-
+    # For configs 'fast', 'pr_aha', 'pr_submod', 'full', 'resnet', see regress_tests/tests.py
     else:
-        raise NotImplementedError(f"Unknown test config: {args.config}")
+        imported_tests = Tests(args.config)
 
+    # Unpack imported_tests into convenient handles
+    width, height = imported_tests.width, imported_tests.height
+    sparse_tests = imported_tests.sparse_tests
+    glb_tests = imported_tests.glb_tests
+    glb_tests_fp = imported_tests.glb_tests_fp
+    resnet_tests = imported_tests.resnet_tests
+    resnet_tests_fp = imported_tests.resnet_tests_fp
+    hardcoded_dense_tests = imported_tests.hardcoded_dense_tests
 
     print(f"--- Running regression: {args.config}", flush=True)
     info = []
@@ -757,7 +535,7 @@ def dispatch(args, extra_args=None):
                 info.append([test + "_glb dense only", t0 + t1 + t2, t0, t1, t2])
  
     print(f"+++ TIMING INFO", flush=True)
-    print(tabulate(info, headers=["step", "total", "compile", "map", "test"]), flush=True)
+    print(tabulate(info, headers=["step", "total", "compile", "map", "test"], floatfmt=".0f"), flush=True)
 
 
 def gather_tests(tags):

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -23,6 +23,9 @@ class Tests:
             glb_tests_fp = [
                 "tests/fp_pointwise",
             ]
+            resnet_tests = []
+            resnet_tests_fp = []
+            hardcoded_dense_tests = []
 
         # PR_AHA test suite for aha-repo push/pull
         elif testname == "pr_aha":
@@ -37,7 +40,7 @@ class Tests:
             # hour range.)
 
             # 2. THEN we broke the 8-10 hour "pr_aha" test into three 3-hour
-            # tests pr_aha1,2,3 that can all run in parallel (see below).
+            # tests pr_aha1,2,3 that can all run in parallel.
 
             width, height = 28, 16
             sparse_tests = [
@@ -185,6 +188,8 @@ class Tests:
                 "spmv_relu",
                 "masked_broadcast",
                 "trans_masked_broadcast",
+                "mat_dn2sp",
+                "mat_sp2dn",
                 # Turned off until SUB ordering fixed in mapping
                 # 'mat_residual',
                 "mat_sddmm",

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -1,0 +1,298 @@
+class Tests:
+
+    def __init__(self, testname):
+
+        # Defaults
+        width, height = 28, 16  # default
+        sparse_tests = []
+        glb_tests = []
+        glb_tests_fp = []
+        resnet_tests = []
+        resnet_tests_fp = []
+        hardcoded_dense_tests = []
+
+        # FAST test suite should complete in just a minute or two
+        if testname == "fast":
+            width, height = 4, 4
+            sparse_tests = [
+                "vec_identity"
+            ]
+            glb_tests = [
+                "apps/pointwise"
+            ]
+            glb_tests_fp = [
+                "tests/fp_pointwise",
+            ]
+
+        # PR_AHA test suite for aha-repo push/pull
+        elif testname == "pr_aha":
+
+            # aha pull requests used to invoke the much larger "daily"
+            # suite; which we deleted. Now, aha PRs invoke this pared-down
+            # test "pr_aha", (as recommended by Kalhan et al.).  Pr_aha is
+            # kind of an enhanced version of the old "pr" suite of tests,
+            # which was used by pull requests from AHA submodule repos.
+            # The old "pr" suite is now called "pr_submod". (Pr_submod
+            # only takes a couple of hours whereas pr_aha is in the 8-10
+            # hour range.)
+
+            # 2. THEN we broke the 8-10 hour "pr_aha" test into three 3-hour
+            # tests pr_aha1,2,3 that can all run in parallel (see below).
+
+            width, height = 28, 16
+            sparse_tests = [
+                "vec_elemmul",
+                "mat_vecmul_ij",
+                "mat_elemadd_leakyrelu_exp",
+                "mat_elemdiv",
+                "mat_mattransmul",
+                "matmul_ijk_crddrop_relu",
+                "matmul_ikj",
+                "matmul_jik",
+                "spmm_ijk_crddrop_relu",
+                "spmv_relu",
+                "masked_broadcast",
+                "mat_sddmm",
+                "tensor3_mttkrp",
+                "tensor3_ttv",        
+            ]
+            glb_tests = [
+                "apps/pointwise",
+                "apps/gaussian",
+                "apps/camera_pipeline_2x2",
+            ]
+            glb_tests_fp = [
+                "apps/matrix_multiplication_fp",
+            ]
+            resnet_tests = [
+                "conv1",
+                "conv2_x",
+                "conv5_1",
+                "conv5_x",
+            ]
+            resnet_tests_fp = [
+                "conv2_x_fp"
+            ]
+            hardcoded_dense_tests = [
+                "apps/depthwise_conv"
+            ]
+
+# Found the better way maybe
+# 
+#         # PR_AHA tests broken into three sub-parts: aha_pr1
+#         elif testname == "pr_aha1":
+#             t = Tests('aha_pr')
+#             
+#             # FIXME surely there is a better way of doing this part...!!
+#             width, height = (t.width, t.height)
+#             sparse_tests = t.sparse_tests
+#             glb_tests = t.glb_tests
+#             glb_tests_fp = t.glb_tests_fp
+#             resnet_tests = t.resnet_tests
+#             resnet_tests_fp = t.resnet_tests_fp
+#             hardcoded_dense_tests = t.hardcoded_dense_tests
+# 
+#             # Remove conv2 benchmarks, which take about 1.5 hr each...
+#             resnet_tests.remove('conv2_x')  # This is actually *two* tests
+#             resnet_tests_fp.remove('conv2_x_fp')
+# 
+#         # PR_AHA tests broken into three sub-parts: aha_pr2
+#         elif testname == 'pr_aha2':
+#             glb_tests = ["apps/gaussian"]  # conv2 breaks if don't do gaussian first :(
+#             resnet_tests = [ 'conv2_x' ]   # This is actually *two* tests
+# 
+#         # PR_AHA tests broken into three sub-parts: aha_pr2
+#         elif testname == 'pr_aha3':
+#             glb_tests = ["apps/gaussian"]  # conv2 breaks if don't do gaussian first :(
+#             resnet_tests_fp = [ 'conv2_x_fp' ]
+
+        # PR_SUBMOD tests for push/pull from aha submod repos
+        elif testname == "pr_submod":
+
+            # This is the OLD / original two-hour submod pr, I think, from
+            # 611c8bb4, before I mucked things up...before that, this set
+            # of tests was called simply "pr"
+
+            width, height = 28, 16
+            sparse_tests = [
+                "vec_elemadd",
+                "vec_elemmul",
+                "vec_identity",
+                "vec_scalar_mul",
+                "mat_vecmul_ij",
+                "mat_elemadd",
+                "mat_elemadd_relu",
+                "matmul_ijk",
+                "matmul_ijk_crddrop",
+                "matmul_ijk_crddrop_relu",
+                # Turned off until SUB ordering fixed in mapping
+                # 'mat_residual',
+                "mat_vecmul_iter",
+                "tensor3_elemadd",
+                "tensor3_ttm",
+                "tensor3_ttv",
+            ]
+            glb_tests = [
+                "apps/pointwise",
+                "tests/ushift",
+                "tests/arith",
+                "tests/absolute",
+                "tests/scomp",
+                "tests/ucomp",
+                "tests/uminmax",
+                "tests/rom",
+                "tests/conv_1_2",
+                "tests/conv_2_1",
+            ]
+            glb_tests_fp = [
+                "tests/fp_pointwise",
+                "tests/fp_arith",
+                "tests/fp_comp",
+                "tests/fp_conv_7_7",
+            ]
+            resnet_tests = []
+            resnet_tests_fp = []
+            hardcoded_dense_tests = [
+                "apps/depthwise_conv"
+            ]
+
+        # FULL test is used by scheduled weekly aha regressions
+        elif testname == "full":
+
+            width, height = 28, 16
+            sparse_tests = [
+                "vec_elemadd",
+                "vec_elemmul",
+                "vec_identity",
+                "vec_scalar_mul",
+                "mat_vecmul_ij",
+                "mat_elemadd",
+                "mat_elemadd_relu",
+                "mat_elemadd_leakyrelu_exp",
+                "mat_elemadd3",
+                "mat_elemmul",
+                "mat_elemdiv",
+                "mat_identity",
+                "mat_mattransmul",
+                "matmul_ijk",
+                "matmul_ijk_crddrop",
+                "matmul_ijk_crddrop_relu",
+                "matmul_ikj",
+                "matmul_jik",
+                "spmm_ijk_crddrop",
+                "spmm_ijk_crddrop_relu",
+                "spmv",
+                "spmv_relu",
+                "masked_broadcast",
+                "trans_masked_broadcast",
+                # Turned off until SUB ordering fixed in mapping
+                # 'mat_residual',
+                "mat_sddmm",
+                "mat_mask_tri",
+                "mat_vecmul_iter",
+                "tensor3_elemadd",
+                "tensor3_elemmul",
+                "tensor3_identity",
+                "tensor3_innerprod",
+                "tensor3_mttkrp",
+                "tensor3_mttkrp_unfused1",
+                "tensor3_mttkrp_unfused2",
+                "tensor3_ttm",
+                "tensor3_ttv",
+
+            ]
+            glb_tests = [
+                "apps/pointwise",
+                "tests/rom",
+                "tests/arith",
+                "tests/absolute",
+                "tests/boolean_ops",
+                "tests/equal",
+                "tests/ternary",
+                "tests/scomp",
+                "tests/ucomp",
+                "tests/sminmax",
+                "tests/uminmax",
+                "tests/sshift",
+                "tests/ushift",
+                "tests/conv_1_2",
+                "tests/conv_2_1",
+                "tests/conv_3_3",
+                "apps/gaussian",
+                "apps/brighten_and_blur",
+                "apps/cascade",
+                "apps/harris",
+                "apps/resnet_layer_gen",
+                "apps/unsharp",
+                "apps/harris_color",
+                "apps/camera_pipeline_2x2",
+                "apps/maxpooling",
+                "apps/matrix_multiplication"
+            ]
+            glb_tests_fp = [
+                "tests/fp_pointwise",
+                "tests/fp_arith",
+                "tests/fp_comp",
+                "tests/fp_conv_7_7",
+                "apps/maxpooling_fp",
+                "apps/matrix_multiplication_fp",
+                "apps/mcunet_in_sequential_0_fp",
+            ]
+
+            # FIXME would it be better here to do e.g.
+            # resnet_tests = Tests('resnet').resnet_tests ?
+
+            resnet_tests = [
+                "conv1",
+                "conv2_x",
+                "conv3_1",
+                "conv3_x",
+                "conv4_1",
+                "conv4_x",
+                "conv5_1",
+                "conv5_x",
+                "conv2_x_residual",
+                "conv5_x_residual",
+            ]
+            resnet_tests_fp = [
+                "conv2_x_fp"
+            ]
+            hardcoded_dense_tests = [
+                "apps/depthwise_conv"
+            ]
+        elif testname == "resnet":
+            width, height = 28, 16
+            sparse_tests = []
+            glb_tests = []
+            glb_tests_fp = []
+            resnet_tests = [
+                "conv1",
+                "conv2_x",
+                "conv3_1",
+                "conv3_x",
+                "conv4_1",
+                "conv4_x",
+                "conv5_1",
+                "conv5_x",
+                "conv2_x_residual",
+                "conv3_x_residual",
+                "conv4_x_residual",
+                "conv5_x_residual",
+            ]
+            resnet_tests_fp = []
+            hardcoded_dense_tests = []
+
+        # BLANK can be used to return default height, width, and blank test lists
+        elif testname == "BLANK":
+            pass
+
+        else:
+            raise NotImplementedError(f"Unknown test config: {args.config}")
+
+        self.width, self.height = width, height
+        self.sparse_tests = sparse_tests
+        self.glb_tests = glb_tests
+        self.glb_tests_fp = glb_tests_fp
+        self.resnet_tests = resnet_tests
+        self.resnet_tests_fp = resnet_tests_fp
+        self.hardcoded_dense_tests = hardcoded_dense_tests


### PR DESCRIPTION
Cleaning up from previous changes. The *BIG* change here is the offloading of regression suite lists from `regress.py` to subpackage/class `tests.py`. Here is a full description of all the changes I made:

### Changes to `regress.py`

* restored `pr_aha` test suite; so now can run either `aha regress pr_aha` alone or `aha regress pr_aha[123]` as separate subtasks
* offloaded test-suite declarations to a new package `regress_tests/tests.py`

Oh. Also: simplified the TIMING INFO report to use whole integer seconds for runtimes instead of reporting millisecond-level fractions(!)

### CI-related changes that you probably are not very interested in:

* `custom-checkout.sh`: inconsequential comments and such
* `regress-metahooks.sh`: part of pipeline.yml refactor
* `update-pr-repo.sh`: inconsequential comments and such
* `pipeline.yml`
  * offloaded redundant computation to subscript `regress-metahooks.sh`
  * fixed a bug that was preventing aha pull-request tests from running correctly
  * eliminated gimmicky and unnecessary docker plugins, except for the gold runs
