### PR TITLE
implement retry strategy

### DIFF
--- a/aha/aha.py
+++ b/aha/aha.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import pkgutil
 import aha.util
+import subprocess
 
 
 def main():
@@ -53,6 +54,7 @@ def main():
         for retry in [1,2,3]:
             try:
                 args.dispatch(args, extra_args)
+                break
             except subprocess.CalledProcessError as e:
                 if 'SIGSEGV' in str(e):
                     print(f'\n\n{e}\n')  # Print the error msg

--- a/aha/aha.py
+++ b/aha/aha.py
@@ -50,8 +50,7 @@ def main():
     # execute, accepting `args` as the only argument
     if getattr(args, "dispatch", None):
 
-        # In case of SIGSEGV, retry up to three times
-        for retry in [1,2,3]:
+        for retry in [1,2,3]:  # In case of SIGSEGV, retry up to three times
             try:
                 args.dispatch(args, extra_args)
                 break
@@ -60,6 +59,8 @@ def main():
                     print(f'\n\n{e}\n')  # Print the error msg
                     print(f'*** ERROR subprocess died {retry} time(s) with SIGSEGV')
                     print('*** Will retry three times, then give up.\n\n')
+                    if retry == 3:
+                        raise
 
     else:
         parser.print_help()

--- a/aha/aha.py
+++ b/aha/aha.py
@@ -48,7 +48,17 @@ def main():
     # Each subcommand sets args.dispatch to the command it wants to
     # execute, accepting `args` as the only argument
     if getattr(args, "dispatch", None):
-        args.dispatch(args, extra_args)
+
+        # In case of SIGSEGV, retry up to three times
+        for retry in [1,2,3]:
+            try:
+                args.dispatch(args, extra_args)
+            except subprocess.CalledProcessError as e:
+                if 'SIGSEGV' in str(e):
+                    print(f'\n\n{e}\n')  # Print the error msg
+                    print(f'*** ERROR subprocess died {retry} time(s) with SIGSEGV')
+                    print('*** Will retry three times, then give up.\n\n')
+
     else:
         parser.print_help()
 

--- a/aha/util/garnet.py
+++ b/aha/util/garnet.py
@@ -10,6 +10,21 @@ def add_subparser(subparser):
 
 
 def dispatch(args, extra_args=None):
-    subprocess.check_call(
-        [sys.executable, "garnet.py"] + extra_args, cwd=args.aha_dir / "garnet",
-    )
+    for retry in [1,2,3]:  # In case of SIGSEGV, retry up to three times
+        try:
+            subprocess.check_call(
+                [sys.executable, "garnet.py"] + extra_args, cwd=args.aha_dir / "garnet",
+            )
+            break
+        except subprocess.CalledProcessError as e:
+            if 'SIGSEGV' in str(e):
+                print(f'\n\n{e}\n')  # Print the error msg
+                print(f'*** ERROR subprocess died {retry} time(s) with SIGSEGV')
+                print('*** Will retry three times, then give up.\n\n')
+
+                # if retry == 3: raise
+                # - No! Don't raise the error! Higher-level aha.py has similar
+                # - three-retry catchall, resulting in up to nine retries ! (Right?)
+                # - Do this instead:
+                if retry == 3:
+                    assert False, 'ERROR: Three time loser'


### PR DESCRIPTION
For background see e-mail thread "Regression Convo."

I think this is the simplest fix for our SIGSEGV problems. For now, the fix is specific to SIGSEG errors in called subprocesses. However, it would be trivial to broaden the scope such that we get three retries on *any* error, or any subprocess error, etc.

What think you (anyone)? Opinions?
