### PR TITLE
Offload buildkite steps to repo for better version control

### DIFF
--- a/.buildkite/bin/aha-flow-steps.sh
+++ b/.buildkite/bin/aha-flow-steps.sh
@@ -1,0 +1,58 @@
+# https://buildkite.com/stanford-aha/aha-flow/settings/steps
+# should have something like this:
+# 
+# env:
+#     # DEV_BRANCH: master
+#     DEV_BRANCH: offload-steps
+# 
+# steps:
+# - label: ":pipeline:"
+#   agents: { docker: true }
+#   command: echo DONE
+#   plugins:
+#     # Turn off normal/slow repo+submods checkout b/c all we need is pipeline.yml
+#     - uber-workflow/run-without-clone:
+#     
+#     # Even though we turned off cloning, I think there's a reasone why
+#     # we do commands in pre-checkout phase, but I can't quite remember why...?
+#     - improbable-eng/metahook:
+#         pre-checkout: |
+#             set -x
+#             mkdir -p DELETEME-aha-flow-{$BUILDKITE_BUILD_NUMBER}
+#             udev=https://github.com/StanfordAHA/aha/blob/$$DEV_BRANCH/aha-flow-steps.sh
+#             umaster=https://github.com/StanfordAHA/aha/blob/master/aha-flow-steps.sh
+#             httpcode=`curl $$udev -o $$TMPDIR/aha-flow-steps.sh`
+#             if ! [ $httpcode == 200 ]; then
+#                 echo "Cannot find steps in branch '$$DEV_BRANCH'; trying master instead"
+#                 export DEV_BRANCH=master  # FIXME things break if DEV_BRANCH not set
+#                 curl $$umaster -o $$TMPDIR/aha-flow-steps.sh
+#             fi
+#             set +x
+#             source $$TMPDIR/aha-flow-steps.sh
+
+set +u;  # My code assumes unset vars are okay
+echo "+++ Must have a (empty!) working directory"; set -x;
+d=$BUILDKITE_BUILD_CHECKOUT_PATH;
+/bin/rm -rf $d; mkdir -p $d; ls -ld $d; cd $d;
+
+echo "--- CUSTOM CHECKOUT BEGIN"; set -x;
+echo "Fast checkout w/ no submod loads (yet)";
+aha_clone=$BUILDKITE_BUILD_CHECKOUT_PATH;
+git clone https://github.com/StanfordAHA/aha $aha_clone; cd $aha_clone;
+
+# My scripts don't deal well with a commit that's not a full hash!
+if [ "$BUILDKITE_COMMIT" == "HEAD" ]; then
+    BUILDKITE_COMMIT=`git rev-parse HEAD`; fi
+if ! git checkout -q $BUILDKITE_COMMIT; then
+    echo "Submod commit hash found, using aha master branch";
+    git checkout -q $DEV_BRANCH || echo "No dev branch found, continuing w master..."; fi;
+
+# git checkout -q $BUILDKITE_COMMIT || echo "Submod commit hash found, using aha master branch";
+# git checkout -q $BUILDKITE_COMMIT || git checkout -q $DEV_BRANCH || echo "No dev branch found, continuing w master...";
+
+# Note, /home/buildkite-agent/bin/status-update must exist on agent machine
+# Also see ~steveri/bin/status-update on kiwi
+echo "+++ Notify github of pending status"; ~/bin/status-update --force pending;
+grep conv2 .buildkite/pipeline.yml || echo not found oh no;
+buildkite-agent pipeline upload .buildkite/pipeline.yml;
+echo "--- CUSTOM CHECKOUT END"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -232,4 +232,3 @@ steps:
   # Not exactly sure why '--no-prune' is included...?
   commands:
     - docker image rm "garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}" --no-prune
-    - /bin/rm -rf $$COMMON

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,6 +81,10 @@ steps:
   commands:
   - echo "+++ BDI PIPELINE.XML COMMANDS BEGIN"
 
+  # Remove DELETEME* dirs older than one week
+  - echo "--- Cleanup old common areas"
+  - find /var/lib/buildkite-agent/builds/DELETEME* -type d -mtime -7 -exec /bin/rm -rf {} \; || echo okay
+
   - echo "--- Save repo things in common area"
   - mkdir -p $$COMMON
   - cp $$BUILDKITE_BUILD_CHECKOUT_PATH/.buildkite/bin/regress-metahooks.sh $$COMMON

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -167,6 +167,7 @@ steps:
         pre-exit:    $REGRESS_METAHOOKS --pre-exit
 
   commands:
+    - exit 13
     - docker kill $$CONTAINER || echo okay
     - docker run -id --name $$CONTAINER --rm -v /cad:/cad -v ./temp:/buildkite:rw $$IMAGE bash
     - script="$($REGRESS_METAHOOKS --commands)"
@@ -187,6 +188,7 @@ steps:
         pre-exit:    $REGRESS_METAHOOKS --pre-exit
 
   commands:
+    - exit 13
     - docker kill $$CONTAINER || echo okay
     - docker run -id --name $$CONTAINER --rm -v /cad:/cad -v ./temp:/buildkite:rw $$IMAGE bash
     - script="$($REGRESS_METAHOOKS --commands)"
@@ -206,6 +208,7 @@ steps:
         pre-exit:    $REGRESS_METAHOOKS --pre-exit
 
   commands:
+    - exit 13
     - docker kill $$CONTAINER || echo okay
     - docker run -id --name $$CONTAINER --rm -v /cad:/cad -v ./temp:/buildkite:rw $$IMAGE bash
     - script="$($REGRESS_METAHOOKS --commands)"

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -399,13 +399,14 @@ def dispatch(args, extra_args=None):
     imported_tests = None
 
     # pr_aha1,2,3 are 4-hour, 3-hour, and 3-hour slices of pr_aha, respectively
+    # pr_aha1 starts with the full pr_aha suite and removes conv2, conv2_fp
     if args.config == "pr_aha1":
         imported_tests = Tests("pr_aha")
         imported_tests.resnet_tests.remove('conv2_x')  # This is actually *two* tests
         imported_tests.resnet_tests_fp.remove('conv2_x_fp')
 
+    # pr_aha2 is just conv2 by itself (it runs both sparse and dense versions tho)
     # NOTE conv2 breaks if don't do gaussian first(!) for details see issues:
-    # https://github.com/StanfordAHA/garnet/issues/1070
     # https://github.com/StanfordAHA/aha/issues/1897
     elif args.config == "pr_aha2":
         imported_tests = Tests("BLANK")


### PR DESCRIPTION
Previously, the initial steps for the buildkite aha-flow test were only on the web page <https://buildkite.com/stanford-aha/aha-flow/settings/steps>. Over time, the steps have become somewhat complex, and now it makes sense that they should be under version control in the aha repo.

So. I have moved the major functionality into a separate script such that all the online steps have to do is find, load, and run the script from the repo. Later, if all goes well, I will do the same for aha-submod-flow steps <https://buildkite.com/stanford-aha/aha-flow/settings/steps>.

Also hidden in this pull are a couple of comment-tweaks for regress.py.

