### PR TITLE
Dockreduce

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -99,8 +99,8 @@ steps:
   - set -x; docker images; docker ps;
 
   - echo "--- Remove 700MB of clockwork, halide metadata"
-  - dotgit=.git/modules/clockwork;          du -shx $dotgit; /bin/rm -rf $$dotgit
-  - dotgit=.git/modules/Halide-to-Hardware; du -shx $dotgit; /bin/rm -rf $$dotgit
+  - dotgit=.git/modules/clockwork;          du -shx $$dotgit; /bin/rm -rf $$dotgit
+  - dotgit=.git/modules/Halide-to-Hardware; du -shx $$dotgit; /bin/rm -rf $$dotgit
 
   - echo "--- Creating garnet Image"
   - docker build --progress plain . -t "$$IMAGE"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -98,6 +98,10 @@ steps:
   - echo "--- DEBUG DOCKER TRASH"
   - set -x; docker images; docker ps;
 
+  - echo "--- Remove 700MB of clockwork, halide metadata"
+  - dotgit=.git/modules/clockwork;          du -shx $dotgit; /bin/rm -rf $$dotgit
+  - dotgit=.git/modules/Halide-to-Hardware; du -shx $dotgit; /bin/rm -rf $$dotgit
+
   - echo "--- Creating garnet Image"
   - docker build --progress plain . -t "$$IMAGE"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -217,6 +217,11 @@ steps:
 - wait: { continue_on_failure: true } 
 
 - label: "Cleanup"
+
+  # Don't need time-wasting clone just for cleanup! Right?
+  plugins:
+    - uber-workflow/run-without-clone:
+
   command: |
 
     echo '- Show outcomes from each regression step'

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,15 +10,19 @@ on:
     - cron: '0 11 * * 0'
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+
+    - name: Delete clockwork and halide metadata
+      run: |
+        du -shx     .git/modules/clockwork .git/modules/Halide-to-Hardware
+        /bin/rm -rf .git/modules/clockwork .git/modules/Halide-to-Hardware
+
     - name: Publish Docker image
       uses: elgohr/Publish-Docker-Github-Action@2.12
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,7 @@ RUN cd /aha && git clone https://github.com/weiya711/sam.git && \
   \
   echo "Cleanup: 420M .git metadata, to be restored by bashrc on startup" && \
   (du -shx /aha/.modules/clockwork || echo okay) && \
+  (du -shx /aha/clockwork || echo okay) && \
   rm -rf /aha/.modules/clockwork
 
 # Sam 2 - build sam
@@ -234,6 +235,8 @@ COPY ./aha /aha/aha
 
 WORKDIR /aha
 RUN source bin/activate && \
+  echo "FOO NOT YET, right?" && \
+  (du -shx /aha/.modules/clockwork || echo okay) && \
   echo "--- ..Final aha deps install" && \
   pip install -e . && \
   aha deps install
@@ -242,6 +245,15 @@ RUN source bin/activate && \
 # in EVERYTHING. Anything from here on down CANNOT BE CACHED.
 WORKDIR /aha
 COPY . /aha
+RUN cd /aha && \
+  echo "FOO here it is, right?" && \
+  (du -shx /aha/.modules/clockwork || echo okay) && \
+  \
+  echo "Cleanup: 420M .git metadata, to be restored by bashrc on startup" && \
+  (du -shx /aha/.modules/clockwork || echo okay) && \
+  rm -rf /aha/.modules/clockwork && \
+  (du -shx /aha/.modules/clockwork || echo okay) && \
+  echo DONE
 
 ENV OA_UNSUPPORTED_PLAT=linux_rhel60
 ENV USER=docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,24 +177,16 @@ RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
       rm -rf /aha/Halide-to-Hardware/include/Halide.h.gch/  && \
       rm -rf /aha/Halide-to-Hardware/distrib/{bin,lib}      && \
       rm -rf /aha/Halide-to-Hardware/bin/build/llvm_objects && \
-      echo "Wait, does clockwork metadata exist yet?" && \
-      (du -shx /aha/.git/modules/clockwork || echo okay) && \
     echo DONE
 
 # Sam 1 - clone and set up sam
-# ??? Is this where ALL SUBMODULES get initialized ???
 COPY ./.git/modules/sam/HEAD /tmp/HEAD
 RUN cd /aha && git clone https://github.com/weiya711/sam.git && \
   cd /aha/sam && \
   mkdir -p /aha/.git/modules && \
   mv .git/ /aha/.git/modules/sam/ && \
   ln -s /aha/.git/modules/sam/ .git && \
-  git checkout `cat /tmp/HEAD` && git submodule update --init --recursive && \
-  \
-  echo "Cleanup: 420M .git metadata, to be restored by bashrc on startup" && \
-  (du -shx /aha/.git/modules/clockwork || echo okay) && \
-  (du -shx /aha/clockwork || echo okay) && \
-  rm -rf /aha/.git/modules/clockwork
+  git checkout `cat /tmp/HEAD` && git submodule update --init --recursive
 
 # Sam 2 - build sam
 COPY ./sam /aha/sam
@@ -235,8 +227,6 @@ COPY ./aha /aha/aha
 
 WORKDIR /aha
 RUN source bin/activate && \
-  echo "FOO NOT YET, right?" && \
-  (du -shx /aha/.git/modules/clockwork || echo okay) && \
   echo "--- ..Final aha deps install" && \
   pip install -e . && \
   aha deps install
@@ -245,15 +235,6 @@ RUN source bin/activate && \
 # in EVERYTHING. Anything from here on down CANNOT BE CACHED.
 WORKDIR /aha
 COPY . /aha
-RUN cd /aha && \
-  echo "FOO here it is, right?" && \
-  (du -shx /aha/.git/modules/clockwork || echo okay) && \
-  \
-  echo "Cleanup: 420M .git metadata, to be restored by bashrc on startup" && \
-  (du -shx /aha/.git/modules/clockwork || echo okay) && \
-  rm -rf /aha/.git/modules/clockwork && \
-  (du -shx /aha/.git/modules/clockwork || echo okay) && \
-  echo DONE
 
 ENV OA_UNSUPPORTED_PLAT=linux_rhel60
 ENV USER=docker
@@ -264,17 +245,6 @@ ENV USER=docker
 # 2. Tell user how to restore gch headers.
 
 RUN echo "source /aha/aha/bin/docker-bashrc" >> /root/.bashrc && echo DONE
-
-# RUN echo "source /aha/bin/activate"        >> /root/.bashrc && \
-#     echo "mkdir -p /root/.modules"         >> /root/.bashrc && \
-#     echo "source /cad/modules/tcl/init/sh" >> /root/.bashrc && \
-#     echo 'echo ""                                      ' >> /root/.bashrc && \
-#     echo 'echo "For pre-compiled Halide 'gch' headers:"' >> /root/.bashrc && \
-#     echo 'echo "    cd /aha/Halide-to-Hardware"        ' >> /root/.bashrc && \
-#     echo 'echo "    rm include/Halide.h"               ' >> /root/.bashrc && \
-#     echo 'echo "    make include/Halide.h"             ' >> /root/.bashrc && \
-#     echo 'echo ""                                      ' >> /root/.bashrc && \
-#     echo DONE
 
 # Restore halide distrib files on every container startup
 ENTRYPOINT [ "/aha/aha/bin/restore-halide-distrib.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -178,7 +178,7 @@ RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
       rm -rf /aha/Halide-to-Hardware/distrib/{bin,lib}      && \
       rm -rf /aha/Halide-to-Hardware/bin/build/llvm_objects && \
       echo "Wait, does clockwork metadata exist yet?" && \
-      (du -shx /aha/.modules/clockwork || echo okay) && \
+      (du -shx /aha/.git/modules/clockwork || echo okay) && \
     echo DONE
 
 # Sam 1 - clone and set up sam
@@ -192,9 +192,9 @@ RUN cd /aha && git clone https://github.com/weiya711/sam.git && \
   git checkout `cat /tmp/HEAD` && git submodule update --init --recursive && \
   \
   echo "Cleanup: 420M .git metadata, to be restored by bashrc on startup" && \
-  (du -shx /aha/.modules/clockwork || echo okay) && \
+  (du -shx /aha/.git/modules/clockwork || echo okay) && \
   (du -shx /aha/clockwork || echo okay) && \
-  rm -rf /aha/.modules/clockwork
+  rm -rf /aha/.git/modules/clockwork
 
 # Sam 2 - build sam
 COPY ./sam /aha/sam
@@ -236,7 +236,7 @@ COPY ./aha /aha/aha
 WORKDIR /aha
 RUN source bin/activate && \
   echo "FOO NOT YET, right?" && \
-  (du -shx /aha/.modules/clockwork || echo okay) && \
+  (du -shx /aha/.git/modules/clockwork || echo okay) && \
   echo "--- ..Final aha deps install" && \
   pip install -e . && \
   aha deps install
@@ -247,12 +247,12 @@ WORKDIR /aha
 COPY . /aha
 RUN cd /aha && \
   echo "FOO here it is, right?" && \
-  (du -shx /aha/.modules/clockwork || echo okay) && \
+  (du -shx /aha/.git/modules/clockwork || echo okay) && \
   \
   echo "Cleanup: 420M .git metadata, to be restored by bashrc on startup" && \
-  (du -shx /aha/.modules/clockwork || echo okay) && \
-  rm -rf /aha/.modules/clockwork && \
-  (du -shx /aha/.modules/clockwork || echo okay) && \
+  (du -shx /aha/.git/modules/clockwork || echo okay) && \
+  rm -rf /aha/.git/modules/clockwork && \
+  (du -shx /aha/.git/modules/clockwork || echo okay) && \
   echo DONE
 
 ENV OA_UNSUPPORTED_PLAT=linux_rhel60

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -11,7 +11,22 @@ cat << EOF
 
 EOF
 
+cat << EOF
+  Restoring submodule metadata in the background.
+  To monitor progress, can 'cat' or 'tail' log files e.g.
+      tail -f /tmp/restore-clockwork
+      tail -f /tmp/restore-halide
+
+EOF
 # Restore 420MB of clockwork .git data + 320MB of halide data
-echo "Restore submodule metadata"
-/aha/aha/bin/restore-dotgit.sh clockwork
-/aha/aha/bin/restore-dotgit.sh Halide-to-Hardware
+(
+  echo '/aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork'
+  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork
+  echo "Finished restoring clockwork metadata"
+) &
+(
+  echo '/aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide'
+  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide
+  echo "Finished restoring halide metadata"
+) &
+

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -1,0 +1,16 @@
+source /aha/bin/activate
+mkdir -p /root/.modules
+source /cad/modules/tcl/init/sh
+
+cat << EOF
+
+  For pre-compiled Halide gch headers:
+      cd /aha/Halide-to-Hardware        
+      rm include/Halide.h               
+      make include/Halide.h             
+
+EOF
+
+# Restore 420MB of clockwork .git data
+echo "Restore submodule metadata"
+/aha/aha/bin/restore-dotgit.sh clockwork

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -11,6 +11,7 @@ cat << EOF
 
 EOF
 
-# Restore 420MB of clockwork .git data
+# Restore 420MB of clockwork .git data + 320MB of halide data
 echo "Restore submodule metadata"
 /aha/aha/bin/restore-dotgit.sh clockwork
+/aha/aha/bin/restore-dotgit.sh Halide-to-Hardware

--- a/aha/bin/restore-dotgit.sh
+++ b/aha/bin/restore-dotgit.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+HELP="
+Usage:   restore-dot-git.sh <submod-name>
+Example: test -e /aha/.git/modules/clockwork || $0 clockwork
+"
+if ! [ "$1" ]; then echo "$HELP"; exit 13; fi
+
+submod=$1
+dotgit=/aha/.git/modules/$submod
+
+if test -e $dotgit; then
+    echo ""
+    echo "  $submod metadata exists, so will not run '$0 $submod'"
+    echo "  If you really want to do this, remove '$dotgit' and try again."
+    echo ""
+    exit
+fi
+
+echo "------------------------------------------------------------------------"
+echo "--- $0 $1"
+echo "--- Restoring .git metadata for submodule '$submod'"
+
+echo ""
+echo "--- Find desired 'official' submod hash"
+#  999dc896fc716f57e539f8819e4436a1b4d5c7bc clockwork (detailed_timing)
+# submod_sha=999dc896f
+cd /aha
+git submodule | grep $submod | cut -b 2-1000
+git submodule | grep $submod | cut -b 2-10
+submod_sha=`git submodule | grep $submod | cut -b 2-10`
+
+# E.g. url=https://github.com/StanfordAHA/clockwork.git
+echo ""
+url=`git config --file=/aha/.gitmodules submodule.$submod.url`
+echo "--- Restore metadata from repo '$url'"
+git clone --bare "$url" /aha/.git/modules/$submod
+
+# Convert bare repo into something useful, with a work tree
+cd /aha/$submod; git config --local --bool core.bare false
+
+echo ""
+echo "--- Restore '$submod' branch '$submod_sha'"
+cd /aha/$submod; git checkout -f $submod_sha
+
+echo ""
+echo "--- Remove unnecessary local branches"
+git for-each-ref --format '%(refname:short)' refs/heads \
+   | egrep -v "^(master|main)$" \
+   | xargs git branch -D
+
+echo ""
+echo "+++ DONE"
+printf "\ngit status\n"; git status -uno
+printf "\ngit branch\n"; git branch
+
+
+
+
+
+##############################################################################
+# OLD/DELETEME
+
+# (cd $submod; git branch) # FAILS b/c no .git, duh
+
+# echo ""; echo "Remove existing metadata '$d'"
+# cd /aha/.git/modules; test -d $submod && /bin/rm -rf $d || echo okay

--- a/aha/bin/restore-dotgit.sh
+++ b/aha/bin/restore-dotgit.sh
@@ -53,15 +53,3 @@ echo ""
 echo "+++ DONE"
 printf "\ngit status\n"; git status -uno
 printf "\ngit branch\n"; git branch
-
-
-
-
-
-##############################################################################
-# OLD/DELETEME
-
-# (cd $submod; git branch) # FAILS b/c no .git, duh
-
-# echo ""; echo "Remove existing metadata '$d'"
-# cd /aha/.git/modules; test -d $submod && /bin/rm -rf $d || echo okay


### PR DESCRIPTION
Also see issue https://github.com/StanfordAHA/aha/issues/1937 .

This is phase one of a project to try and reduce the size of our AHA docker image.

In this first phase, I found that it's fairly easy to delete and restore github metadata, which in the AHA repo accounts for well over a gigabyte of disk space. In particular, two submodules, *clockwork* and *Halide-to-Hardware,* together account for over 700MB.

So. I rejiggered our docker-build scripts `pipeline.yml` and `dockerimage.yml` to delete clockwork and Halide-to-Hardware metadata before building the docker image.  Then, I altered the docker's `.bashrc` to restore the metadata to its original state on first invocation of a new container. This takes an extra minute when a user first fires it up, but then never needs to happen again for the life of the container.

Going forward, then, our docker size should be smaller by 700MB, or about 10%. And in fact, it looks as if we will be at 6.6GB after this change, down from the previous 7.4GB.
```
% docker images
REPOSITORY          TAG         IMAGE ID       CREATED       SIZE
stanfordaha/garnet  dockreduce  3fcdaf27e220   2 hours ago   6.62GB (new)
stanfordaha/garnet  latest      510195ae1716   2 days ago    7.41GB (old)
```
