### PR TITLE
Docker no clang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,9 +72,7 @@ RUN apt-get update && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 \
                         --slave   /usr/bin/g++ g++ /usr/bin/g++-9 && \
     pip install cmake && \
-    wget -nv -O ~/clang7.tar.xz http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
-    tar -xvf ~/clang7.tar.xz --strip-components=1 -C /usr/ && \
-    rm -rf ~/clang7.tar.xz
+    echo DONE
 
 # Switch shell to bash
 SHELL ["/bin/bash", "--login", "-c"]
@@ -168,15 +166,31 @@ RUN ./misc/install_deps_ahaflow.sh && \
       rm -rf /aha/clockwork/*.o /aha/clockwork/bin/*.o && \
     echo DONE
 
-# Halide-to-Hardware
+# Halide-install step, below, modified to delete 1G of clang when finished.
+# Clang will be restored by way of .bashrc (aha/bin/docker-bashrc).
+
+# Halide-to-Hardware - Step 32/65 ish - requires clang
 COPY ./Halide-to-Hardware /aha/Halide-to-Hardware
 WORKDIR /aha/Halide-to-Hardware
-RUN export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
+RUN \
+  : CLANG-INSTALL && \
+    echo "Install 1G of clang/llvm" && \
+      url=http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
+      wget -nv -O ~/clang7.tar.xz $url && \
+      tar -xvf ~/clang7.tar.xz --strip-components=1 -C /usr/ && \
+      rm -rf ~/clang7.tar.xz && \
+  : BUILD && \
+    echo "Build and test Halide compiler" && \
+      export COREIR_DIR=/aha/coreir && make -j2 && make distrib && \
+  : CLEANUP && \
     echo "Cleanup: 200M lib, 400M gch, 200M distrib, 100M llvm" && \
       rm -rf lib/* && \
       rm -rf /aha/Halide-to-Hardware/include/Halide.h.gch/  && \
       rm -rf /aha/Halide-to-Hardware/distrib/{bin,lib}      && \
       rm -rf /aha/Halide-to-Hardware/bin/build/llvm_objects && \
+    echo "Cleanup: 1G clang in /usr, will be restored by bashrc" && \
+      rm -rf /usr/*/{*clang*,*llvm*,*LLVM*} && \
+  : DONE && \
     echo DONE
 
 # Sam 1 - clone and set up sam
@@ -193,6 +207,7 @@ COPY ./sam /aha/sam
 RUN echo "--- ..Sam 2" && cd /aha/sam && make sam && \
   source /aha/bin/activate && pip install scipy numpy pytest && pip install -e .
 
+# ------------------------------------------------------------------------------
 # Final pip installs: AHA Tools etc.
 
 # Note kratos is slow but stable; maybe it should be installed much earlier in dockerfile
@@ -200,10 +215,7 @@ RUN echo "--- ..Sam 2" && cd /aha/sam && make sam && \
 # For "aha deps install"; copy all the modules that not yet been copied
 COPY ./archipelago /aha/archipelago
 COPY ./ast_tools /aha/ast_tools
-# COPY ./BufferMapping /aha/BufferMapping
 COPY ./canal /aha/canal
-# COPY ./cgra_pnr/cyclone /aha/cgra_pnr/cyclone
-# COPY ./cgra_pnr/thunder /aha/cgra_pnr/thunder
 COPY ./cgra_pnr /aha/cgra_pnr
 COPY ./cosa /aha/cosa
 COPY ./fault /aha/fault

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -25,12 +25,12 @@ EOF
 
 ( echo '  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork'
   /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork
-  echo "Finished restoring clockwork metadata"
+  print "\nFinished restoring clockwork metadata\n"
 ) &
 
 ( echo '  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide'
   /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide
-  echo "Finished restoring halide metadata"
+  printf "\nFinished restoring halide metadata\n"
 ) &
 
 ########################################################################
@@ -46,8 +46,10 @@ EOF
 ( url=http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
   echo "  wget $url"
   wget -nv -O ~/clang7.tar.xz $url
+  echo ""
   tar -xvf ~/clang7.tar.xz --strip-components=1 -C /usr/ >& /tmp/restore-clang
   rm -rf ~/clang7.tar.xz
+  print "\nFinished restoring clang\n"
 ) &
 
 sleep 4

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -25,7 +25,7 @@ EOF
 
 ( echo '  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork'
   /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork
-  print "\nFinished restoring clockwork metadata\n"
+  printf "\nFinished restoring clockwork metadata\n"
 ) &
 
 ( echo '  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide'
@@ -49,7 +49,7 @@ EOF
   echo ""
   tar -xvf ~/clang7.tar.xz --strip-components=1 -C /usr/ >& /tmp/restore-clang
   rm -rf ~/clang7.tar.xz
-  print "\nFinished restoring clang\n"
+  printf "\nFinished restoring clang\n"
 ) &
 
 sleep 4

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -17,8 +17,8 @@ EOF
 cat << EOF
   Restoring submodule metadata in the background.
   To monitor progress, can 'cat' or 'tail' log files e.g.
-      tail -f /tmp/restore-clockwork
-      tail -f /tmp/restore-halide
+      tail /tmp/restore-clockwork
+      tail /tmp/restore-halide
 
 EOF
 # Restore 420MB of clockwork .git data + 320MB of halide data
@@ -36,9 +36,16 @@ EOF
 ########################################################################
 # Restore clang - do it in the background for minimal disruption
 
-( url=http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-  wget -nv -O ~/clang7.tar.xz $url
-  tar -xvf ~/clang7.tar.xz --strip-components=1 -C /usr/
+cat << EOF
+  Restoring clang and llvm in the background.
+  To monitor progress, can 'cat' or 'tail' log file e.g.
+      tail /tmp/restore-clang
+
+EOF
+( echo 'wget clang7.tar.xz'
+  url=http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+  wget -nv -O ~/clang7.tar.xz $url >& /tmp/restore-clang
+  tar -xvf ~/clang7.tar.xz --strip-components=1 -C /usr/ >>& /tmp/restore-clang
   rm -rf ~/clang7.tar.xz
 ) &
 

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -11,6 +11,9 @@ cat << EOF
 
 EOF
 
+########################################################################
+# Restore submodules - do it in the background for minimal disruption
+
 cat << EOF
   Restoring submodule metadata in the background.
   To monitor progress, can 'cat' or 'tail' log files e.g.
@@ -19,14 +22,23 @@ cat << EOF
 
 EOF
 # Restore 420MB of clockwork .git data + 320MB of halide data
-(
-  echo '/aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork'
+
+( echo '/aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork'
   /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork
   echo "Finished restoring clockwork metadata"
 ) &
-(
-  echo '/aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide'
+
+( echo '/aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide'
   /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide
   echo "Finished restoring halide metadata"
+) &
+
+########################################################################
+# Restore clang - do it in the background for minimal disruption
+
+( url=http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+  wget -nv -O ~/clang7.tar.xz $url
+  tar -xvf ~/clang7.tar.xz --strip-components=1 -C /usr/
+  rm -rf ~/clang7.tar.xz
 ) &
 

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -36,14 +36,15 @@ EOF
 ########################################################################
 # Restore clang - do it in the background for minimal disruption
 
-cat << EOF
+test -f /usr/bin/clang-7 || cat << EOF
 
   Restoring clang and llvm in the background.
   To monitor progress, can 'cat' or 'tail' log file e.g.
       tail /tmp/restore-clang
 
 EOF
-( url=http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+test -f /usr/bin/clang-7 || (
+  url=http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
   echo "  wget $url"
   wget -nv -O ~/clang7.tar.xz $url
   echo ""
@@ -52,4 +53,4 @@ EOF
   printf "\nFinished restoring clang\n"
 ) &
 
-sleep 4
+sleep 1

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -23,12 +23,12 @@ cat << EOF
 EOF
 # Restore 420MB of clockwork .git data + 320MB of halide data
 
-( echo '/aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork'
+( echo '  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork'
   /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork
   echo "Finished restoring clockwork metadata"
 ) &
 
-( echo '/aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide'
+( echo '  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide'
   /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide
   echo "Finished restoring halide metadata"
 ) &
@@ -37,15 +37,17 @@ EOF
 # Restore clang - do it in the background for minimal disruption
 
 cat << EOF
+
   Restoring clang and llvm in the background.
   To monitor progress, can 'cat' or 'tail' log file e.g.
       tail /tmp/restore-clang
 
 EOF
-( echo 'wget clang7.tar.xz'
-  url=http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-  wget -nv -O ~/clang7.tar.xz $url >& /tmp/restore-clang
-  tar -xvf ~/clang7.tar.xz --strip-components=1 -C /usr/ >>& /tmp/restore-clang
+( url=http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+  echo "  wget $url"
+  wget -nv -O ~/clang7.tar.xz $url
+  tar -xvf ~/clang7.tar.xz --strip-components=1 -C /usr/ >& /tmp/restore-clang
   rm -rf ~/clang7.tar.xz
 ) &
 
+sleep 4


### PR DESCRIPTION
Reduces docker image by a further 1-GB ish, by deleting its `clang` install before writing the image. As before, `.bashrc` re-installs clang on container startup. The reinstall is even faster than the `.git` reinstall added in my previous PR (https://github.com/StanfordAHA/aha/pull/1939), it only takes about 10-20 seconds at most, and just for good measure it happens in the background as well. So the impact on users should be extremely minimal.

`clang` is used in the process of compiling Halide, I think, so we keep it for the convenience of Halide developers who use the container.

(Note, to be clear, this has nothing per se to do with the lego/gcc issue we've been discussing...)
