### PR TITLE
Remove libboost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,6 @@ RUN apt-get update && \
         # sam
         graphviz \
         xxd \
-        # lego
-        libboost-all-dev \
         # pono
         time \ 
         m4 \


### PR DESCRIPTION
1. Remove libbost from the list of packages installed in the Dockerfile
2. Updated Lego so now it no longer depends on libboost