### PR TITLE
Remove version req for python package "packaging"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN source bin/activate && \
   pip install urllib3==1.26.15 && \
   pip install wheel six && \
   pip install systemrdl-compiler peakrdl-html && \
-  pip install packaging==21.3 && \
+  pip install packaging && \
   pip install importlib_resources && \
   echo DONE
 


### PR DESCRIPTION
This change is designed to resolve issue https://github.com/StanfordAHA/aha/issues/1949 and fix Max's broken CI https://buildkite.com/stanford-aha/aha-flow/builds/10718

See issue writeup (link above) for details.