### PR TITLE
Fix h2h remote branches

### DIFF
--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -23,19 +23,14 @@ cat << EOF
 EOF
 # Restore 420MB of clockwork .git data + 320MB of halide data
 
-DBG=1
-( echo '  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork';
-# /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork;
-  /aha/aha/bin/restore-dotgit.sh clockwork |& tee /tmp/restore-clockwork;
+( echo '  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork'
+  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork
   printf "\nFinished restoring clockwork metadata\n"
-  cd /aha/clockwork; git -r |& head
 ) &
 
-( echo '  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide';
-# /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide;
-  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware |& tee /tmp/restore-halide;
+( echo '  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide'
+  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide
   printf "\nFinished restoring halide metadata\n"
-  cd /aha/Halide-to-Hardware; git -r |& head
 ) &
 
 ########################################################################

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -23,13 +23,16 @@ cat << EOF
 EOF
 # Restore 420MB of clockwork .git data + 320MB of halide data
 
-( echo '  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork'
-  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork
+DBG=1
+( echo '  /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork';
+# /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork;
+  /aha/aha/bin/restore-dotgit.sh clockwork |& tee /tmp/restore-clockwork;
   printf "\nFinished restoring clockwork metadata\n"
 ) &
 
-( echo '  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide'
-  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide
+( echo '  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide';
+# /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide;
+  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware |& tee /tmp/restore-halide;
   printf "\nFinished restoring halide metadata\n"
 ) &
 

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -28,12 +28,14 @@ DBG=1
 # /aha/aha/bin/restore-dotgit.sh clockwork >& /tmp/restore-clockwork;
   /aha/aha/bin/restore-dotgit.sh clockwork |& tee /tmp/restore-clockwork;
   printf "\nFinished restoring clockwork metadata\n"
+  cd /aha/clockwork; git -r |& head
 ) &
 
 ( echo '  /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide';
 # /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware >& /tmp/restore-halide;
   /aha/aha/bin/restore-dotgit.sh Halide-to-Hardware |& tee /tmp/restore-halide;
   printf "\nFinished restoring halide metadata\n"
+  cd /aha/Halide-to-Hardware; git -r |& head
 ) &
 
 ########################################################################

--- a/aha/bin/restore-dotgit.sh
+++ b/aha/bin/restore-dotgit.sh
@@ -52,22 +52,17 @@ git for-each-ref --format '%(refname:short)' refs/heads \
 echo ""
 echo "--- Restore remote-branch access"
 cd /aha/$submod
-echo "BEFORE: git branch -r |& head"
-git branch -r |& head -3
+# echo "BEFORE: git branch -r |& head"
+# git branch -r |& head -3
+# echo 'NOW: git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"'
+set -x
 git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 git fetch -p
-echo "AFTER: git branch -r |& head"
-git branch -r |& head -3
+set +x
+# echo "AFTER: git branch -r |& head"
+# git branch -r |& head -3
 
 echo ""
 echo "+++ DONE"
 printf "\ngit status\n"; git status -uno
 printf "\ngit branch\n"; git branch
-
-DBG=1
-if [ "$DBG" ]; then
-  if [ "$submod" == "Halide-to-Hardware" ]; then
-    test -f /tmp/restore-halide && cat /tmp/restore-halide
-  fi
-fi
-

--- a/aha/bin/restore-dotgit.sh
+++ b/aha/bin/restore-dotgit.sh
@@ -50,6 +50,24 @@ git for-each-ref --format '%(refname:short)' refs/heads \
    | xargs git branch -D
 
 echo ""
+echo "--- Restore remote-branch access"
+cd /aha/$submod
+echo "BEFORE: git branch -r |& head"
+git branch -r |& head -3
+git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+git fetch -p
+echo "AFTER: git branch -r |& head"
+git branch -r |& head -3
+
+echo ""
 echo "+++ DONE"
 printf "\ngit status\n"; git status -uno
 printf "\ngit branch\n"; git branch
+
+DBG=1
+if [ "$DBG" ]; then
+  if [ "$submod" == "Halide-to-Hardware" ]; then
+    test -f /tmp/restore-halide && cat /tmp/restore-halide
+  fi
+fi
+

--- a/aha/bin/restore-dotgit.sh
+++ b/aha/bin/restore-dotgit.sh
@@ -51,16 +51,11 @@ git for-each-ref --format '%(refname:short)' refs/heads \
 
 echo ""
 echo "--- Restore remote-branch access"
-cd /aha/$submod
-# echo "BEFORE: git branch -r |& head"
-# git branch -r |& head -3
-# echo 'NOW: git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"'
 set -x
+cd /aha/$submod
 git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 git fetch -p
 set +x
-# echo "AFTER: git branch -r |& head"
-# git branch -r |& head -3
 
 echo ""
 echo "+++ DONE"


### PR DESCRIPTION
Before this pull, could not access remote branches from submodules `clockwork` or `Halide-to-Hardware`:
```
  % cd /aha/Halide-to-Hardware
  % git branch -r | head
      <nothing>
```

After merging these changes, remote branches should once again be available:
```
  % cd /aha/Halide-to-Hardware
  % git branch -r | head
      origin/bfloat-meta
      origin/clockwork
      origin/clockwork-aha
      ...
```
