### PR TITLE
Disallow clean checkout

### DIFF
--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -16,9 +16,9 @@ PS4="."   # Prevents "+++" prefix during 3-deep "set -x" execution
 echo "+++ BEGIN custom-checkout.sh"
 echo I am in dir `pwd`
 
-echo "--- Must have a (empty!) working directory"
-d=$BUILDKITE_BUILD_CHECKOUT_PATH;
-/bin/rm -rf $d; mkdir -p $d; ls -ld $d; cd $d
+set -x
+echo "I see BUILDKITE_CLEAN_CHECKOUT=$BUILDKITE_CLEAN_CHECKOUT"
+
 
 # should DIE if $BUILDKITE_CLEAN_CHECKOUT==true
 if [ "$BUILDKITE_CLEAN_CHECKOUT" == "true" ]; then
@@ -28,6 +28,10 @@ if [ "$BUILDKITE_CLEAN_CHECKOUT" == "true" ]; then
     echo "ERROR: That's-a no good. I am .buildkite/bin/custom-checkout.sh"
     exit 13
 fi
+
+echo "--- Must have a (empty!) working directory"
+d=$BUILDKITE_BUILD_CHECKOUT_PATH;
+/bin/rm -rf $d; mkdir -p $d; ls -ld $d; cd $d
 
 echo "--- Clone the repo"
 aha_clone=$BUILDKITE_BUILD_CHECKOUT_PATH;

--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -17,8 +17,17 @@ echo "+++ BEGIN custom-checkout.sh"
 echo I am in dir `pwd`
 echo I see commit `git log | head -1` || echo okay
 
+
+
+
+
+
 set -x
 echo "I see BUILDKITE_CLEAN_CHECKOUT=$BUILDKITE_CLEAN_CHECKOUT"
+
+
+
+
 
 
 # should DIE if $BUILDKITE_CLEAN_CHECKOUT==true
@@ -41,6 +50,24 @@ cd $aha_clone;
 
 # FIXME things break if DEV_BRANCH not set?
 [ "$DEV_BRANCH" ] || export DEV_BRANCH=master
+
+
+
+
+# TODO TODO TODO
+# # TROUBLE maybe if DEV_BRANCH==HEAD but BUILDKITE_BRANCH==disallow-clean-checkout etc.
+# # Want this to work for HEAD, HEAD~1 etc.
+# if expr "$DEV_BRANCH" : "HEAD" > /dev/null; then
+#     if [ "$BUILDKITE_BRANCH" ]; then
+#         # This will turn "HEAD~1" into e.g. "disallow-clean-checkout~1"
+#         DEV_BRANCH=`echo $DEV_BRANCH | sed "s/HEAD/$BUILDKITE_BRANCH/"`
+#     fi
+# fi
+
+
+
+
+
 
 if ! git checkout -q $DEV_BRANCH; then
     export DEV_BRANCH=master
@@ -135,7 +162,7 @@ else
     git fetch -v --prune -- origin $BUILDKITE_COMMIT || echo okay
 
     if ! git checkout -qf $BUILDKITE_COMMIT; then
-        echo "Submod commit hash found, using aha master branch";
+        echo "Submod commit hash not found, using aha master branch";
         git checkout -q $DEV_BRANCH || echo "No dev branch found, continuing w master..."; fi;
 fi
 

--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -19,10 +19,12 @@ echo I see commit `git log | head -1` || echo okay
 
 # should DIE if $BUILDKITE_CLEAN_CHECKOUT==true
 if [ "$BUILDKITE_CLEAN_CHECKOUT" == "true" ]; then
-    echo "ERROR: BUILDKITE_CLEAN_CHECKOUT=$BUILDKITE_CLEAN_CHECKOUT"
-    echo "ERROR: It looks like maybe someone started a job manually from the"
-    echo "ERROR: buildkite web interface and clicked the 'clean checkout' option"
-    echo "ERROR: That's-a no good. I am .buildkite/bin/custom-checkout.sh"
+    echo "
+    ERROR: BUILDKITE_CLEAN_CHECKOUT=$BUILDKITE_CLEAN_CHECKOUT
+    ERROR: It looks like maybe someone started a job manually from the
+    ERROR: buildkite web interface and clicked the 'clean checkout' option
+    ERROR: That's-a no good. I am .buildkite/bin/custom-checkout.sh
+"
     exit 13
 fi
 

--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -20,6 +20,15 @@ echo "--- Must have a (empty!) working directory"
 d=$BUILDKITE_BUILD_CHECKOUT_PATH;
 /bin/rm -rf $d; mkdir -p $d; ls -ld $d; cd $d
 
+# should DIE if $BUILDKITE_CLEAN_CHECKOUT==true
+if [ "$BUILDKITE_CLEAN_CHECKOUT" == "true" ]; then
+    echo "ERROR: BUILDKITE_CLEAN_CHECKOUT=$BUILDKITE_CLEAN_CHECKOUT"
+    echo "ERROR: It looks like maybe someone started a job manually from the"
+    echo "ERROR: buildkite web interface and clicked the 'clean checkout' option"
+    echo "ERROR: That's-a no good. I am .buildkite/bin/custom-checkout.sh"
+    exit 13
+fi
+
 echo "--- Clone the repo"
 aha_clone=$BUILDKITE_BUILD_CHECKOUT_PATH;
 test -e $aha_clone/.git || git clone https://github.com/StanfordAHA/aha $aha_clone

--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -15,7 +15,6 @@ PS4="."   # Prevents "+++" prefix during 3-deep "set -x" execution
 
 echo "+++ BEGIN custom-checkout.sh"
 echo I am in dir `pwd`
-echo I see commit `git log | head -1` || echo okay
 
 # should DIE if $BUILDKITE_CLEAN_CHECKOUT==true
 if [ "$BUILDKITE_CLEAN_CHECKOUT" == "true" ]; then

--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -17,19 +17,6 @@ echo "+++ BEGIN custom-checkout.sh"
 echo I am in dir `pwd`
 echo I see commit `git log | head -1` || echo okay
 
-
-
-
-
-
-set -x
-echo "I see BUILDKITE_CLEAN_CHECKOUT=$BUILDKITE_CLEAN_CHECKOUT"
-
-
-
-
-
-
 # should DIE if $BUILDKITE_CLEAN_CHECKOUT==true
 if [ "$BUILDKITE_CLEAN_CHECKOUT" == "true" ]; then
     echo "ERROR: BUILDKITE_CLEAN_CHECKOUT=$BUILDKITE_CLEAN_CHECKOUT"
@@ -50,24 +37,6 @@ cd $aha_clone;
 
 # FIXME things break if DEV_BRANCH not set?
 [ "$DEV_BRANCH" ] || export DEV_BRANCH=master
-
-
-
-
-# TODO TODO TODO
-# # TROUBLE maybe if DEV_BRANCH==HEAD but BUILDKITE_BRANCH==disallow-clean-checkout etc.
-# # Want this to work for HEAD, HEAD~1 etc.
-# if expr "$DEV_BRANCH" : "HEAD" > /dev/null; then
-#     if [ "$BUILDKITE_BRANCH" ]; then
-#         # This will turn "HEAD~1" into e.g. "disallow-clean-checkout~1"
-#         DEV_BRANCH=`echo $DEV_BRANCH | sed "s/HEAD/$BUILDKITE_BRANCH/"`
-#     fi
-# fi
-
-
-
-
-
 
 if ! git checkout -q $DEV_BRANCH; then
     export DEV_BRANCH=master

--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -15,6 +15,7 @@ PS4="."   # Prevents "+++" prefix during 3-deep "set -x" execution
 
 echo "+++ BEGIN custom-checkout.sh"
 echo I am in dir `pwd`
+echo I see commit `git log | head -1` || echo okay
 
 set -x
 echo "I see BUILDKITE_CLEAN_CHECKOUT=$BUILDKITE_CLEAN_CHECKOUT"


### PR DESCRIPTION
Because of how our buildkite CI process works, certain tests will FAIL if the user requests a 'clean checkout.' We can see an example of this in Yuchen's attempt to manually test an aha branch `point_master_flush_pond` <https://buildkite.com/stanford-aha/aha-flow/builds/11216>. (Thanks Yuchen for providing the example that helped me find this bug!)

Specifically, if you are on a buildkite page and you click "New Build," you can specify "Clean Checkout" as one of the options. But this interferes poorly with our own custom checkout procedure (`.buildkite/bin/custom-checkout.sh`) and causes the retry to fail. Rerunning the build with 'clean checkout' unselected fixes the problem, e.g. <https://buildkite.com/stanford-aha/aha-flow/builds/11248>

This PR implements an error message such that, if someone tries to do the wrong thing, it will die with enough information that they will know how to correct the problem.

Examples:
* "new build" attempt using clean checkout fails immediately with cogent error message: https://buildkite.com/stanford-aha/aha-flow/builds/11264
* "new build" attempt *without* clean checkout succeeds: https://buildkite.com/stanford-aha/aha-flow/builds/11265
