### PR TITLE
Aha test wrapper

### DIFF
--- a/aha/bin/app
+++ b/aha/bin/app
@@ -64,10 +64,8 @@ while [ $# -gt 0 ] ; do
         --help)        echo "$HELP";  exit ;;
 
         # New and undocumented
-        --update*) 
-            UPDATE_SRC=$1; shift;
-            UPDATE_DST=$1; shift;
-            ;;
+        --update*) UPDATE_SRC=$2; UPDATE_DST=$3; shift 2 ;;
+
         # TODO/FIXME Backward compatibility / DELETE after a couple months / TODAY is 08 April 2025 ish
         --fp) echo 'WARNING "--fp" deprecated/unnecessary, stop using it'; ;;
 
@@ -90,8 +88,32 @@ done
 
 ########################################################################
 # Find file tests.py
+# TESTS_PY=/aha/aha/util/regress_tests/tests.py
+# test -e $TESTS_PY || TESTS_PY=/nobackup/steveri/github$TESTS_PY
+
+# echo IN CONTAINER NOW\?
+# echo hostname=`hostname`
+# ls -l /aha
+# ls -l /aha/aha
+# ls -l /aha/aha/util
+
+set -x
 TESTS_PY=/aha/aha/util/regress_tests/tests.py
-test -e $TESTS_PY || TESTS_PY=/nobackup/steveri/github/$TESTS_PY
+echo "1 TESTS_PY='$TESTS_PY'"
+ls -l $TESTS_PY
+test -e $TESTS_PY && echo EXISTS || echo NOT EXISTS
+
+test -e $TESTS_PY || TESTS_PY=/nobackup/steveri/github$TESTS_PY
+echo "2 TESTS_PY='$TESTS_PY'"
+ls -l $TESTS_PY
+
+
+
+
+
+set +x
+
+
 
 ##############################################################################
 ##############################################################################
@@ -107,7 +129,8 @@ test -e $TESTS_PY || TESTS_PY=/nobackup/steveri/github/$TESTS_PY
 
 ########################################################################
 # HLINE e.g. 'hline 5' = "-----\n"
-function hline { ncol=$1; while [ "$ncol" -gt 0 ] ; do echo -n -; ((ncol-=1)); done; echo ""; }
+# Beware how you do this, can be a nightmare for 'set -x' if you get it wrong
+function hline { seq -s- $1 | sed 's/[^-]//g'; }
 
 ########################################################################
 # Parse 'tests.py' to find suite names e.g.
@@ -163,6 +186,7 @@ for s in $TEST_SUITES; do
         echo '------------------------------------------------------------------------'
     fi
     this_suite=`python3 <(cat $TESTS_PY; printf "$tests_py_stub")`
+    # Gather all the this_suite's together in a single 'suites'
     suites="$(printf "%s\n%s" "$suites" "$this_suite")"
 done
 if [ "$DBG" ]; then hline 72; (echo "$suites" | head); fi
@@ -260,7 +284,6 @@ if ! [ "$IN_DOCKER" ]; then
 #     docker cp ~/tmpdir/tests.py $container:/aha/aha/util/regress_tests/tests.py
 #     docker cp ~/tmpdir/regress.py $container:/aha/aha/util/regress.py
 
-
 # TODO: reuse-container mechanism
 # 
 # container=DELETEME-$USER-apptest-$$
@@ -269,66 +292,48 @@ if ! [ "$IN_DOCKER" ]; then
 # # Note this will err if reusing container, but that's okay maybe.
 # docker run -id --name $container --rm $CAD $image bash || echo okay
 
-########################################################################
-########################################################################
-########################################################################
-# TODO
-if [ "$UPDATE_SRC" ]; then
-    # GROUP "UPDATE docker repo '$UPDATE_DST' w local repo '$UPDATE_SRC'"
-    echo "UPDATE docker repo '$UPDATE_DST' w local repo '$UPDATE_SRC'"
-    exit
+    ########################################################################
+    # Update container repo if requested with --update switch, e.g.
+    #    app ... --update /nobackup/steveri/github/garnet /aha/garnet
+    #    app ... --update . /aha/aha
 
-    # Copy local garnet branch to /tmp/deleteme-garnet-$$
+    if [ "$UPDATE_SRC" ]; then
+        echo "UPDATE docker repo '$UPDATE_DST' w local repo '$UPDATE_SRC'"
+        # GROUP "UPDATE docker repo '$UPDATE_DST' w local repo '$UPDATE_SRC'"
 
-    # bookmark
-    # TODO what happens if we do this using aha with active submodules???
+        # Copy (cp -r) contents of FROM/SRC repo to a temp dir
+        repo=$(echo $UPDATE_SRC | sed 's|/$||; s|.*/||')
+        tmpdir=/tmp/deleteme-update-$repo-$$
+        /bin/rm -rf $tmpdir; mkdir -p $tmpdir
+        (cd $UPDATE_SRC; git ls-files | xargs -I{} cp -r --parents {} $tmpdir)
 
+        # If updating aha repo, skip top level directory so as not to overwrite submodules :(
+        [ "$UPDATE_DST" == "/aha/" ]    && UPDATE_DST=/aha/aha
+        [ "$UPDATE_DST" == "/aha/aha" ] && tmpdir=$tmpdir/aha
 
-#     /bin/rm -rf /tmp/deleteme-garnet-$$; mkdir -p /tmp/deleteme-garnet-$$
-#     git ls-files | xargs -I{} cp -r --parents {} /tmp/deleteme-garnet-$$
+        # Copy contents of temp dir to its final location in the container
+        docker exec $container /bin/bash -c "rm -rf $UPDATE_DST"  # Remove old repo
+        docker cp $tmpdir $container:$UPDATE_DST                  # Insert new repo
 
-    repo=$(echo $UPDATE_SRC | sed 's|/$||; s|.*/||')
-    tmp=/tmp/deleteme-update-$repo-$$
-    /bin/rm -rf $tmp; mkdir -p $tmp
+        docker exec $container /bin/bash -c "chown -R root:root $UPDATE_DST"
+        /bin/rm -rf $tmpdir
+        # set +x; # ENDGROUP
+    fi
 
-    # Note submod files are not listed as part of 'git ls-files' so we're okay on that
-    git ls-files | xargs -I{} cp -r --parents {} $tmp
-
-    # Then copy into the container
-#     docker exec $container /bin/bash -c "rm -rf /aha/garnet"
-#     docker cp /tmp/deleteme-garnet-$$ $container:/aha/garnet
-#     /bin/rm -rf /tmp/deleteme-garnet-$$
-
-    docker exec $container /bin/bash -c "rm -rf $UPDATE_DST"
-    docker cp $tmp $container:$UPDATE_DST
-    /bin/rm -rf $tmp
-
-    # echo "##[endgroup]"
-    # set +x; echo "##[endgroup]"; set -x
-    set +x; ENDGROUP
-fi
-
-
-
-
-
-    # Copy this script to container and run it there
-    set -x
-    basename=$(basename $0)
-    echo "Copy script $0 to container /tmp/$basename"
-    docker cp $0 $container:/tmp
-    echo "Run /tmp/$basename in container"
-    # docker exec $container /tmp/$basename --$SIM $size $appname --cols-removed $FCR --mu_oc_0 $MU
-    docker exec $container /tmp/$basename $app_flags
+    echo "Run '$bn $app_flags' in container"
+    # docker cp $0 $container:/tmp; docker exec $container /tmp/$basename $app_flags
+    docker exec $container /aha/aha/bin/$bn $app_flags
     set +x
     exit
 fi
 
+# bookmark
 
 #############################################################################
 # E.g. app_flags='8x8 apps/pointwise --num-fabric-cols-removed 4 --mu_oc_0 8'
 hline 78
-printf "Ready to do: app  --$SIM $size $appname --cols-removed $FCR --mu_oc_0 $MU\n\n"
+# printf "Ready to do: app  --$SIM $size $appname --cols-removed $FCR --mu_oc_0 $MU\n\n"
+printf "Ready to do: $bn $app_flags\n\n"
 
 
 ########################################################################
@@ -376,15 +381,13 @@ if True:
     $group = [ '$appname' ]
 EOF
 
-hline 72
-printf "Prepared custom config file /aha/aha/util/regress_tests/$config.py:\n\n"
+echo '------------------------------------------------------------------------'
+printf "Prepared custom config file /aha/aha/util/regress_tests/$config.py\n\n"
+# ls -l /aha/aha/util/regress_tests/$config.py
 cat /aha/aha/util/regress_tests/$config.py | sed 's/^/> /'
 echo ""
 
-# exit
-
 # BOOKMARK
-ls -l /aha/aha/util/regress_tests/config10.py
 
 # I dunno, just run it I guess?
 
@@ -472,3 +475,40 @@ exit
 #     script_home=`where_this_script_lives`
 #     cd $script_home/../..; pwd
 
+# ------------------------------------------------------------------------
+#     # Copy local garnet branch to /tmp/deleteme-garnet-$$
+# 
+#     # bookmark
+#     # TODO what happens if we do this using aha with active submodules???
+#     # /bin/rm -rf /tmp/deleteme-garnet-$$; mkdir -p /tmp/deleteme-garnet-$$
+#     # git ls-files | xargs -I{} cp -r --parents {} /tmp/deleteme-garnet-$$
+# 
+#     printf "\n\nBEFORE /aha/garnet/garnet.py=\n"
+#     docker exec $container /bin/bash -c "ls -l /aha/garnet/garnet.py"
+#     echo "BEFORE /aha/aha="
+#     docker exec $container /bin/bash -c "ls -l /aha/aha | egrep -v ^total"
+# 
+#     printf '\n\n\n'
+#     ls -l $tmpdir
+#     printf '\n\n\n'
+# 
+#     printf "\n\nAFTER /aha/garnet/garnet.py=\n"
+#     docker exec $container /bin/bash -c "ls -l /aha/garnet/garnet.py"
+# 
+#     echo "AFTER /aha/aha="
+#     docker exec $container /bin/bash -c "ls -l /aha/aha | egrep -v ^total"
+#     exit
+# 
+#     # echo "##[endgroup]"
+#     # set +x; echo "##[endgroup]"; set -x
+
+
+
+#     # Copy this script to container and run it there
+#     set -x
+#     basename=$(basename $0)
+#     echo "Copy script $0 to container /tmp/$basename"
+#     docker cp $0 $container:/tmp
+#     echo "Run /tmp/$basename in container"
+#     # docker exec $container /tmp/$basename --$SIM $size $appname --cols-removed $FCR --mu_oc_0 $MU
+#     docker exec $container /tmp/$basename $app_flags

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -4,6 +4,7 @@
 #   --update /local/aha    /aha/aha     # Update docker repo from local
 #   --update /local/garnet /aha/garnet  # Update docker repo from local
 #   --copy          # Copy working script to docker as /aha/aha/bin/app
+#   --container C   # Use existing container "C" to run the app
 
 # To test: see bottom of file, below
 
@@ -28,11 +29,11 @@ HELP="
     --mu <n>       # Same as --mu_oc_0
 
   EXAMPLE(S):
-    $bn 4x2 apps/pointwise
-    $bn 4x2 tests/fp_pointwise
-    $bn 4x2 tests/fp_pointwise --waveform
-    $bn 4x2 tests/fp_pointwise --cols-removed 4 --mu 8
-    $bn --verilator 4x2 apps/pointwise --cols-removed 4 --mu 8
+    $bn 4x2 apps/pointwise --no-zircon
+    $bn 8x8 tests/fp_pointwise
+    $bn 8x8 tests/fp_pointwise --cols-removed 4 --mu 8  # (same as above)
+    $bn 8x8 tests/fp_pointwise --waveform
+    $bn --verilator 8x8 apps/pointwise
 
   QUICK REFERENCE:
     $bn --show-suite fast --zircon
@@ -55,12 +56,15 @@ DBG=
 SIM=vcs
 LIST_SUITES=
 ZIRCON=True
-FCR=0; MU=0  # (fabric_)cols_removed, mu_oc_0 = 0, 0
+FCR=4; MU=8  # (fabric_)cols_removed, mu_oc_0 = 4, 8
 UPDATE_SRC=; UPDATE_DST=;
 COPY_SCRIPT=
+CONTAINER=
+function not_suite { echo "X$1" | egrep ^X- > /dev/null; }
 while [ $# -gt 0 ] ; do
     case "$1" in
-        --show*)      [ "$2" ] && SUITE=$2 || SUITE=all; shift ;;
+        --show*)      
+          if not_suite "$2"; then SUITE='all'; else SUITE="$2"; shift; fi ;;
 
         --*remove*)    FCR=$2;       shift ;;
         --mu*)         MU=$2;        shift ;;
@@ -76,6 +80,7 @@ while [ $# -gt 0 ] ; do
         # New and undocumented
         --copy*) COPY_SCRIPT=True ;;
         --update*) UPDATE_SRC=$2; UPDATE_DST=$3; shift 2 ;;
+        --container) CONTAINER=$2; shift ;;
 
         # TODO/FIXME Backward compatibility / DELETE after a couple months / TODAY is 08 April 2025 ish
         --fp) echo 'WARNING "--fp" deprecated/unnecessary, stop using it'; ;;
@@ -223,6 +228,13 @@ fi
 # If we are not in a container yet, fire one up.
 test -e /aha/aha && IN_DOCKER=True || IN_DOCKER=
 if ! [ "$IN_DOCKER" ]; then
+
+    if [ "$CONTAINER" ]; then
+        echo "Run '$bn $app_flags' in existing container '$CONTAINER'"
+        docker exec $CONTAINER /aha/aha/bin/$bn $app_flags || exit 13
+        exit
+    fi
+
     echo '-------------------------------------------------'
     echo 'Looks like we are not (yet) in a docker container'
     echo 'What I will do is I will'

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -14,6 +14,7 @@ HELP="
   OPTIONAL FLAGS
     --vcs          # Use vcs for RTL simulation (requires vcs license) [DEFAULT]
     --ver          # Use verilator for RTL simulation
+    --waveform     # Generate a waveform for the app test run
     --no-zircon    # Test old (non-zircon) version of CGRA
 
     --removed <n>  # Same as --num-fabric-cols-removed
@@ -22,6 +23,7 @@ HELP="
   EXAMPLE(S):
     $bn 4x2 apps/pointwise
     $bn 4x2 tests/fp_pointwise
+    $bn 4x2 tests/fp_pointwise --waveform
     $bn 4x2 tests/fp_pointwise --cols-removed 4 --mu 8
     $bn --verilator 4x2 apps/pointwise --cols-removed 4 --mu 8
 
@@ -61,6 +63,7 @@ while [ $# -gt 0 ] ; do
         --zircon)     ZIRCON=True         ;;
         --ver*)       SIM=verilator       ;;
         --vcs)        SIM=vcs             ;;
+        --wave*)      export WAVEFORM=1   ;;
         --help)       echo "$HELP";  exit ;;
 
         # New and undocumented
@@ -84,6 +87,8 @@ while [ $# -gt 0 ] ; do
     esac
     shift
 done
+
+[ "$WAVEFORM" ] && printf "\nINFO env var WAVEFORM=='$WAVEFORM'\n"
 
 # echo "remaining args = '$@'"
 
@@ -330,7 +335,8 @@ rm -f garnet/garnet.v  # Get rid of old verilog if it exists
 source /aha/bin/activate
 if [ "$SIM" == vcs ]; then
     printf "PREPARING VCS b/c SIM=$SIM\n\n"
-    . /cad/modules/tcl/init/bash; module load base; module load vcs
+    source /cad/modules/tcl/init/bash; module load base; module load vcs
+    [ "$WAVEFORM" ] && module load verdi
 else
     printf "PREPARING VERILATOR b/c SIM=$SIM\n\n"
     echo /aha/garnet/tests/install-verilator.sh
@@ -352,3 +358,13 @@ else
     echo aha regress $config --no-zircon
     aha regress $config --no-zircon
 fi
+
+if [ "$WAVEFORM" ]; then
+    echo "----------------------------------------------------------------"
+    echo "Looking for waveform file..."
+    echo "ls -l /aha/garnet/tests/test_app/cgra.fsdb"
+    echo "----------------------------------------------------------------"
+    ls -l /aha/garnet/tests/test_app/cgra.fsdb
+fi
+
+    

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -48,6 +48,7 @@ LIST_SUITES=
 ZIRCON=True
 FCR=0; MU=0  # (fabric_)cols_removed, mu_oc_0 = 0, 0
 UPDATE_SRC=; UPDATE_DST=;
+COPY_SCRIPT=
 while [ $# -gt 0 ] ; do
     case "$1" in
         --show*)      [ "$2" ] && SUITE=$2 || SUITE=all; shift ;;
@@ -63,6 +64,7 @@ while [ $# -gt 0 ] ; do
         --help)       echo "$HELP";  exit ;;
 
         # New and undocumented
+        --copy*) COPY_SCRIPT=True ;;
         --update*) UPDATE_SRC=$2; UPDATE_DST=$3; shift 2 ;;
 
         # TODO/FIXME Backward compatibility / DELETE after a couple months / TODAY is 08 April 2025 ish
@@ -252,7 +254,6 @@ if ! [ "$IN_DOCKER" ]; then
     fi
 
     # For debugging; copy latest script in dev to container
-    COPY_SCRIPT=
     if [ "$COPY_SCRIPT" ]; then
         echo "DEBUGGING: Copy contents of '$0' over as '/aha/aha/bin/app'"
         docker cp $0 $container:/aha/aha/bin/$bn

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-bn=$(basename $0)
+bn=$(basename $0); basename=$bn
 HELP="
   DESCRIPTION:
     Launch a docker container and run the indicated app.
@@ -9,6 +9,7 @@ HELP="
     $bn <width>x<height> <app> [ OPTIONAL-FLAGS ]
     $bn --list-suites          # Tell names of regression suites e.g. 'fast', 'pr_aha' etc.
     $bn --show-suite <suite>   # Show contents of specified suite
+    $bn --show                 # Same as '--show-suite all'
 
   OPTIONAL FLAGS
     --vcs          # Use vcs for RTL simulation (requires vcs license) [DEFAULT]
@@ -49,16 +50,17 @@ FCR=0; MU=0  # (fabric_)cols_removed, mu_oc_0 = 0, 0
 UPDATE_SRC=; UPDATE_DST=;
 while [ $# -gt 0 ] ; do
     case "$1" in
+        --show*)      [ "$2" ] && SUITE=$2 || SUITE=all; shift ;;
+
         --*remove*)    FCR=$2;       shift ;;
         --mu*)         MU=$2;        shift ;;
 
-        --list*suite*) LIST_SUITES=notnull ;;
-        --show*suite*) SUITE=$2;     shift ;;
-        --no*zircon)   ZIRCON=False        ;;
-        --zircon)      ZIRCON=True         ;;
-        --ver*)        SIM=verilator       ;;
-        --vcs)         SIM=vcs             ;;
-        --help)        echo "$HELP";  exit ;;
+        --list*)      LIST_SUITES=notnull ;;
+        --no*zircon)  ZIRCON=False        ;;
+        --zircon)     ZIRCON=True         ;;
+        --ver*)       SIM=verilator       ;;
+        --vcs)        SIM=vcs             ;;
+        --help)       echo "$HELP";  exit ;;
 
         # New and undocumented
         --update*) UPDATE_SRC=$2; UPDATE_DST=$3; shift 2 ;;
@@ -150,7 +152,7 @@ done
 if [ "$DBG" ]; then hline 72; (echo "$suites" | head); fi
 
 ########################################################################
-# FILTER function to tabulate output
+# FILTER function to tabulate output w/o changing arg spacing
 #   BEFORE:
 #     app 8x8 vec_identity --num-fabric-cols-removed 4 --mu_oc_0 8
 #     app 8x8 tests/fp_pointwise --num-fabric-cols-removed 4 --mu_oc_0 8
@@ -164,9 +166,9 @@ function filter { sed 's/--/|==/' | column -t -s '|' | sed 's/==/--/'; }
 # Print contents of indicated suite "$SUITE" e.g.
 # 
 #     % app --show-suite fast
-#     app 8x8 vec_identity               --num-fabric-cols-removed 4 --mu_oc_0 8
-#     app 8x8 apps/pointwise             --num-fabric-cols-removed 4 --mu_oc_0 8
-#     app 8x8 tests/fp_pointwise         --num-fabric-cols-removed 4 --mu_oc_0 8
+#     app 8x8 vec_identity       --removed 4 --mu 8
+#     app 8x8 apps/pointwise     --removed 4 --mu 8
+#     app 8x8 tests/fp_pointwise --removed 4 --mu 8
 
 if [ "$SUITE" ]; then
     suites_to_print="$SUITE"
@@ -191,11 +193,6 @@ if [ "$SUITE" ]; then
     exit
 fi
 
-
-# # ------------------------------------------------------------
-# # REGRESSION SUITE: pr_submod
-# app 28x16 vec_elemadd                      --removed 8 --mu 32
-
 ########################################################################
 # If we get this far, it means we are going to to try and run an app
 [ "$DBG" ] && echo "okay here we are we gonna run app '$appname'"
@@ -203,20 +200,7 @@ fi
 ########################################################################
 # App must run inside a docker container.
 # If we are not in a container yet, fire one up.
-
-IN_DOCKER=
-test -e /aha/aha && IN_DOCKER=True
-
-########################################################################
-# Figure out which simulator to use
-
-CAD=
-# TOOL='export TOOL=VERILATOR'  # no more tool! maybe
-if [ "$SIM" == vcs ]; then
-    CAD='-v /cad:/cad'
-    # export TOOL='. /cad/modules/tcl/init/bash; module load base; module load vcs'
-fi
-
+test -e /aha/aha && IN_DOCKER=True || IN_DOCKER=
 if ! [ "$IN_DOCKER" ]; then
     echo '-------------------------------------------------'
     echo 'Looks like we are not (yet) in a docker container'
@@ -225,6 +209,9 @@ if ! [ "$IN_DOCKER" ]; then
     echo '- execute the script there'
     echo '-------------------------------------------------'
 
+    # Must mount /cad if want to use VCS
+    [ "$SIM" == vcs ] && CAD='-v /cad:/cad' || CAD=
+
     # Setup
     image=stanfordaha/garnet:latest
     docker pull $image
@@ -232,7 +219,7 @@ if ! [ "$IN_DOCKER" ]; then
     docker run -id --name $container --rm $CAD $image bash
 
     # Trap and kill docker container on exit ('--rm' no workee, but why?)
-    function cleanup { printf '\n\n'; set -x; docker kill $container; }
+    function cleanup { printf '\n\n'; set -x; docker kill $container || echo okay; }
     trap cleanup EXIT
 
     ########################################################################
@@ -263,21 +250,25 @@ if ! [ "$IN_DOCKER" ]; then
         # set +x; # ENDGROUP
     fi
 
+    # For debugging; copy latest script in dev to container
+    COPY_SCRIPT=
+    if [ "$COPY_SCRIPT" ]; then
+        echo "DEBUGGING: Copy contents of '$0' over as '/aha/aha/bin/app'"
+        docker cp $0 $container:/aha/aha/bin/$bn
+    fi
+
+    # Run script in container now
     echo "Run '$bn $app_flags' in container"
-    # docker cp $0 $container:/tmp; docker exec $container /tmp/$basename $app_flags
-    docker exec $container /aha/aha/bin/$bn $app_flags
-    set +x
+    docker exec $container /aha/aha/bin/$bn $app_flags || exit 13
     exit
 fi
 
-# bookmark
-
 #############################################################################
 # E.g. app_flags='8x8 apps/pointwise --num-fabric-cols-removed 4 --mu_oc_0 8'
-hline 78
-# printf "Ready to do: app  --$SIM $size $appname --cols-removed $FCR --mu_oc_0 $MU\n\n"
+echo '------------------------------------------------------------------------------'
 printf "Ready to do: $bn $app_flags\n\n"
 
+# bookmark
 
 ########################################################################
 # Find which group 'appname' belongs to,

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -1,0 +1,474 @@
+#!/bin/bash
+
+bn=$(basename $0)
+HELP="
+  DESCRIPTION:
+    Launch a docker container and run the indicated app.
+
+  USAGE:
+    $bn <width>x<height> <app> [ OPTIONAL-FLAGS ]
+    $bn --list-suites          # Tell names of regression suites e.g. 'fast', 'pr_aha' etc.
+    $bn --show-suite <suite>   # Show contents of specified suite
+
+  OPTIONAL FLAGS
+    --vcs          # Use vcs for RTL simulation (requires vcs license) [DEFAULT]
+    --ver          # Use verilator for RTL simulation
+    --no-zircon    # Test old (non-zircon) version of CGRA
+
+    --removed <n>  # Same as --num-fabric-cols-removed
+    --mu <n>       # Same as --mu_oc_0
+
+  EXAMPLE(S):
+    $bn 4x2 apps/pointwise
+    $bn 4x2 tests/fp_pointwise
+    $bn 4x2 tests/fp_pointwise --cols-removed 4 --mu 8
+    $bn --verilator 4x2 apps/pointwise --cols-removed 4 --mu 8
+
+  QUICK REFERENCE:
+    $bn --show-suite fast --zircon
+    $bn --show-suite fast --nozircon
+    $bn --show-suite full
+    $bn --show-suite resnet
+    $bn --show-suite all
+
+"
+if [ "$1" == "--help" ]; then echo "$HELP"; exit; fi
+if [ "$1" == "" ];       then echo "$HELP"; exit; fi
+
+# TODO test and/or use REUSE_CONTAINER maybe
+# REUSE_CONTAINER=True  # Uncomment for reusable container (for debugging)
+
+# Unpack the args
+
+# Preserve original flags for later
+app_flags="$@"
+
+# Defaults
+DBG=
+SIM=vcs
+LIST_SUITES=
+ZIRCON=True
+FCR=0; MU=0  # (fabric_)cols_removed, mu_oc_0 = 0, 0
+UPDATE_SRC=; UPDATE_DST=;
+while [ $# -gt 0 ] ; do
+    case "$1" in
+        --*remove*)    FCR=$2;       shift ;;
+        --mu*)         MU=$2;        shift ;;
+
+        --list*suite*) LIST_SUITES=notnull ;;
+        --show*suite*) SUITE=$2;     shift ;;
+        --no*zircon)   ZIRCON=False        ;;
+        --zircon)      ZIRCON=True         ;;
+        --ver*)        SIM=verilator       ;;
+        --vcs)         SIM=vcs             ;;
+        --help)        echo "$HELP";  exit ;;
+
+        # New and undocumented
+        --update*) 
+            UPDATE_SRC=$1; shift;
+            UPDATE_DST=$1; shift;
+            ;;
+        # TODO/FIXME Backward compatibility / DELETE after a couple months / TODAY is 08 April 2025 ish
+        --fp) echo 'WARNING "--fp" deprecated/unnecessary, stop using it'; ;;
+
+        # If first arg is e.g. 8x8, that means we want to actually run a test e.g.
+        # aha-test.sh 8x8 --removed 4 --mu 8 apps/pointwise
+        --*) echo "$HELP"; echo "ERROR: Unknown flag '$1'"; exit 13 ;;
+
+        # E.g. "8x8 apps/pointwise"
+        *x*) size=$1; appname=$2; shift; ;;
+        *) 
+            printf "\n***ERROR*** Unknown command-line arg '$1'\n"
+            echo "$HELP"
+            printf "\n***ERROR*** Unknown command-line arg '$1'\n"
+            exit ;;
+    esac
+    shift
+done
+
+# echo "remaining args = '$@'"
+
+########################################################################
+# Find file tests.py
+TESTS_PY=/aha/aha/util/regress_tests/tests.py
+test -e $TESTS_PY || TESTS_PY=/nobackup/steveri/github/$TESTS_PY
+
+##############################################################################
+##############################################################################
+##############################################################################
+# # Override for debugging TODO remove it
+# TESTS_PY=/home/steveri/tmpdir/tests.py
+# test -e $TESTS_PY || TESTS_PY=/aha/aha/util/regress_tests/tests.py
+# 
+##############################################################################
+##############################################################################
+##############################################################################
+
+
+########################################################################
+# HLINE e.g. 'hline 5' = "-----\n"
+function hline { ncol=$1; while [ "$ncol" -gt 0 ] ; do echo -n -; ((ncol-=1)); done; echo ""; }
+
+########################################################################
+# Parse 'tests.py' to find suite names e.g.
+# TEST_SUITES = "fast pr_aha pr_submod full resnet"
+
+# This selects lines like 'elif testname == "pr_aha":'
+function filter1 { sed -n '/BLANK/d;/^[^#]*if testname/p'; }
+
+# This selects the last word in the above line
+function filter2 { awk -F '"' '{print $(NF-1)}'; }
+
+TEST_SUITES=`cat $TESTS_PY | filter1 | filter2`
+TEST_SUITES=`echo $TEST_SUITES`  # Remove newlines maybe
+
+[ "$DBG" ] && printf "\nDBG Scrubbed tests.py, found test suites: '$TEST_SUITES'\n\n"
+
+########################################################################
+# List suite names if requested, e.g.
+#   app --show-suite fast
+#   app --show-suite pr_aha
+#   app --show-suite pr_submod
+#   app --show-suite full
+#   app --show-suite resnet
+#   app --show-suite all
+
+if [ "$LIST_SUITES" ]; then
+    echo AVAILABLE REGRESSION SUITES:
+    echo "$TEST_SUITES all" | xargs printf "  $bn --show-suite %s\n" | sed 's/,//'
+    exit
+fi
+
+########################################################################
+# Build a COMPACT data structure containing all apps and suites e.g.
+# 
+# fast   sparse_tests   vec_identity       8x8 --removed 4 --mu 8
+# fast   glb_tests      apps/pointwise     8x8 --removed 4 --mu 8
+# fast   glb_tests_fp   tests/fp_pointwise 8x8 --removed 4 --mu 8
+# 
+# pr_aha sparse_tests   vec_elemmul        28x16
+# pr_aha sparse_tests   mat_vecmul_ij      28x16
+
+# TODO sort by group name etc.
+# DBG=
+for s in $TEST_SUITES; do
+    sq="'$s'"
+    tests_py_stub='\nTests('$sq', zircon='$ZIRCON').show_suite('$sq', zircon='$ZIRCON')\n'
+    if [ "$DBG" ]; then
+        printf "$tests_py_stub"
+        echo '------------------------------------------------------------------------'
+        cat -n <(cat $TESTS_PY; printf "$tests_py_stub")
+        echo '------------------------------------------------------------------------'
+        python3 <(cat $TESTS_PY; printf "$tests_py_stub")
+        echo '------------------------------------------------------------------------'
+    fi
+    this_suite=`python3 <(cat $TESTS_PY; printf "$tests_py_stub")`
+    suites="$(printf "%s\n%s" "$suites" "$this_suite")"
+done
+if [ "$DBG" ]; then hline 72; (echo "$suites" | head); fi
+
+########################################################################
+# FILTER function to tabulate output
+#   BEFORE:
+#     app 8x8 vec_identity --num-fabric-cols-removed 4 --mu_oc_0 8
+#     app 8x8 tests/fp_pointwise --num-fabric-cols-removed 4 --mu_oc_0 8
+#   AFTER:
+#     app 8x8 vec_identity       --num-fabric-cols-removed 4 --mu_oc_0 8
+#     app 8x8 tests/fp_pointwise --num-fabric-cols-removed 4 --mu_oc_0 8
+
+function filter { sed 's/--/|==/' | column -t -s '|' | sed 's/==/--/'; }
+
+########################################################################
+# Print contents of indicated suite "$SUITE" e.g.
+# 
+#     % app --show-suite fast
+#     app 8x8 vec_identity               --num-fabric-cols-removed 4 --mu_oc_0 8
+#     app 8x8 apps/pointwise             --num-fabric-cols-removed 4 --mu_oc_0 8
+#     app 8x8 tests/fp_pointwise         --num-fabric-cols-removed 4 --mu_oc_0 8
+
+if [ "$SUITE" ]; then
+    suites_to_print="$SUITE"
+    [ "$SUITE" == ALL ] && SUITE=all
+    [ "$SUITE" == all ] && suites_to_print="$TEST_SUITES"
+    for s in $suites_to_print; do
+        if [ "$SUITE" == all ]; then
+            echo -n "# "; hline 60
+            echo "# REGRESSION SUITE: $s"
+        else 
+            echo ""
+        fi
+        [ "$DBG" ] && echo "$suites" | egrep ^"$s"
+        [ "$DBG" ] && hline 72
+
+        (echo "$suites" | egrep ^"$s" | awk '{
+          suite=$1; group=$2; app=$3; size=$4; $1=$2=$3=$4="";
+          gsub(/^ */, "", $0); parms = $0
+          printf("'$bn' %s %s %s\n", size, app, parms)
+        }') | filter
+    done
+    exit
+fi
+
+
+# # ------------------------------------------------------------
+# # REGRESSION SUITE: pr_submod
+# app 28x16 vec_elemadd                      --removed 8 --mu 32
+
+########################################################################
+# If we get this far, it means we are going to to try and run an app
+[ "$DBG" ] && echo "okay here we are we gonna run app '$appname'"
+
+########################################################################
+# App must run inside a docker container.
+# If we are not in a container yet, fire one up.
+
+IN_DOCKER=
+test -e /aha/aha && IN_DOCKER=True
+
+########################################################################
+# Figure out which simulator to use
+
+CAD=
+# TOOL='export TOOL=VERILATOR'  # no more tool! maybe
+if [ "$SIM" == vcs ]; then
+    CAD='-v /cad:/cad'
+    # export TOOL='. /cad/modules/tcl/init/bash; module load base; module load vcs'
+fi
+
+if ! [ "$IN_DOCKER" ]; then
+# if [ '' ]; then
+    echo '-------------------------------------------------'
+    echo 'Looks like we are not (yet) in a docker container'
+    echo 'What I will do is I will'
+    echo '- launch a container using docker image "garnet:latest"'
+    echo '- copy this script to the container'
+    echo '- execute the script there'
+    echo '-------------------------------------------------'
+
+    # Setup
+    image=stanfordaha/garnet:latest
+    docker pull $image
+    container=deleteme-$USER-aha-test-$$
+    docker run -id --name $container --rm $CAD $image bash
+
+    # Trap and kill docker container on exit ('--rm' no workee, but why?)
+    function cleanup { printf '\n\n'; set -x; docker kill $container; }
+    trap cleanup EXIT
+
+# We're gonna see if we can do this with UPDATE
+#     # Override for debugging TODO remove it
+#     docker cp ~/tmpdir/tests.py $container:/aha/aha/util/regress_tests/tests.py
+#     docker cp ~/tmpdir/regress.py $container:/aha/aha/util/regress.py
+
+
+# TODO: reuse-container mechanism
+# 
+# container=DELETEME-$USER-apptest-$$
+# [ "$REUSE_CONTAINER" ] && container=deleteme-steveri-testapp-dev
+# # Note for verilator CAD="" else CAD="-v /cad:/cad"
+# # Note this will err if reusing container, but that's okay maybe.
+# docker run -id --name $container --rm $CAD $image bash || echo okay
+
+########################################################################
+########################################################################
+########################################################################
+# TODO
+if [ "$UPDATE_SRC" ]; then
+    # GROUP "UPDATE docker repo '$UPDATE_DST' w local repo '$UPDATE_SRC'"
+    echo "UPDATE docker repo '$UPDATE_DST' w local repo '$UPDATE_SRC'"
+    exit
+
+    # Copy local garnet branch to /tmp/deleteme-garnet-$$
+
+    # bookmark
+    # TODO what happens if we do this using aha with active submodules???
+
+
+#     /bin/rm -rf /tmp/deleteme-garnet-$$; mkdir -p /tmp/deleteme-garnet-$$
+#     git ls-files | xargs -I{} cp -r --parents {} /tmp/deleteme-garnet-$$
+
+    repo=$(echo $UPDATE_SRC | sed 's|/$||; s|.*/||')
+    tmp=/tmp/deleteme-update-$repo-$$
+    /bin/rm -rf $tmp; mkdir -p $tmp
+
+    # Note submod files are not listed as part of 'git ls-files' so we're okay on that
+    git ls-files | xargs -I{} cp -r --parents {} $tmp
+
+    # Then copy into the container
+#     docker exec $container /bin/bash -c "rm -rf /aha/garnet"
+#     docker cp /tmp/deleteme-garnet-$$ $container:/aha/garnet
+#     /bin/rm -rf /tmp/deleteme-garnet-$$
+
+    docker exec $container /bin/bash -c "rm -rf $UPDATE_DST"
+    docker cp $tmp $container:$UPDATE_DST
+    /bin/rm -rf $tmp
+
+    # echo "##[endgroup]"
+    # set +x; echo "##[endgroup]"; set -x
+    set +x; ENDGROUP
+fi
+
+
+
+
+
+    # Copy this script to container and run it there
+    set -x
+    basename=$(basename $0)
+    echo "Copy script $0 to container /tmp/$basename"
+    docker cp $0 $container:/tmp
+    echo "Run /tmp/$basename in container"
+    # docker exec $container /tmp/$basename --$SIM $size $appname --cols-removed $FCR --mu_oc_0 $MU
+    docker exec $container /tmp/$basename $app_flags
+    set +x
+    exit
+fi
+
+
+#############################################################################
+# E.g. app_flags='8x8 apps/pointwise --num-fabric-cols-removed 4 --mu_oc_0 8'
+hline 78
+printf "Ready to do: app  --$SIM $size $appname --cols-removed $FCR --mu_oc_0 $MU\n\n"
+
+
+########################################################################
+# Find which group 'appname' belongs to,
+# e.g. group('apps/pointwise') = 'glb_tests' maybe
+
+group=`echo "$suites" | grep $appname | awk '{print $2}' | sort | uniq`
+n_groups_found=`echo "$group" | wc -l`
+if ! [ "$n_groups_found" -eq 1 ]; then
+    echo "WARNING: Found multiple possible groups for app '$appname': " $groups
+    group=`echo "$group" | head -1`
+    echo "Will use first group found '$group'"
+fi
+echo "Found group('$appname') = '$group'"
+
+########################################################################
+# Extract width, height, groupname, regression flags
+# '8x8 apps/pointwise --num-fabric-cols-removed 4 --mu_oc_0 8' =>
+#     colrow: 'self.width, self.height = 4, 2'
+#     rflags: '--num-fabric-cols-removed 4 --mu_oc_0 8'
+
+# colrow=$(echo $size | awk -F x '{printf("self.width, self.height = %s, %s", $1, $2)}')
+colrow=$(echo $size | awk -F x '{printf("width, height = %s, %s", $1, $2)}')
+rflags=$(echo $* | awk '{$1=""; $2=""; gsub(/^ */, "", $0); print $0}')
+if [ "$DBG" ]; then
+    hline 20
+    echo "group:  '$group'"
+    echo "colrow: '$colrow'"
+    echo "rflags: '$rflags'"
+    echo ""
+fi
+
+########################################################################
+# Prepare a custom suite containing ONLY the desired app e.g.
+#     > if True:
+#     >     width, height = 8, 8
+#     >     cols_removed, mu_oc_0 = 8, 32
+#     >     glb_tests = [ 'apps/pointwise' ]
+
+config=config$$
+cat <<EOF > /aha/aha/util/regress_tests/$config.py
+if True:
+    $colrow
+    cols_removed, mu_oc_0 = $FCR, $MU
+    $group = [ '$appname' ]
+EOF
+
+hline 72
+printf "Prepared custom config file /aha/aha/util/regress_tests/$config.py:\n\n"
+cat /aha/aha/util/regress_tests/$config.py | sed 's/^/> /'
+echo ""
+
+# exit
+
+# BOOKMARK
+ls -l /aha/aha/util/regress_tests/config10.py
+
+# I dunno, just run it I guess?
+
+# echo \#\#[group]SETUP
+rm -f garnet/garnet.v  # Get rid of old verilog if it exists
+source /aha/bin/activate
+if [ "$SIM" == vcs ]; then
+    echo "PREPARING VCS b/c SIM=$SIM"
+    . /cad/modules/tcl/init/bash; module load base; module load vcs
+else
+    echo "PREPARING VERILATOR b/c SIM=$SIM"
+    echo /aha/garnet/tests/install-verilator.sh
+    /aha/garnet/tests/install-verilator.sh
+fi
+
+(cd /aha/garnet; make clean)  # In case of e.g. CONTAINER_REUSE
+
+# echo \#\#[endgroup]
+# set -x
+# ls -l /aha/aha/util/regress_tests/
+
+if [ "$ZIRCON" == True ]; then
+    echo aha regress $config
+    aha regress $config
+else
+    echo aha regress $config --no-zircon
+    aha regress $config --no-zircon
+fi
+
+exit
+########################################################################
+# TRASH maybe
+
+# ########################################################################
+# # Remaining flags are the app-run command flags e.g.
+# #   '8x8 apps/pointwise --num-fabric-cols-removed 4 --mu_oc_0 8'
+# 
+# # app_flags=("$@")
+# app_flags=`echo "$@"`
+# if [ "$DBG" ]; then
+#     # Arg check, see if args are surviving through all the shenanigans
+#     echo -n ARGS1:; for a in "$@"; do echo -n "'$a' "; done; echo ';'
+#     echo app_flags="'$app_flags'"
+# fi
+# 
+# # ???
+# # echo 1 aha garnet $size ${garnet_flags[@]} --verilog --use_sim_sram --glb_tile_mem_size 128
+
+# ########################################################################
+# # Check on simulator settings
+# if [ "$DBG" ]; then
+#     echo "SIM='$SIM'"; echo "CAD='$CAD'"; echo ""
+# fi
+# 
+# # ########################################################################
+# # # Install verilator if requested
+# # if [ "$SIM" == verilator ]; then
+# #     echo "INSTALLING VERILATOR"
+# #     echo /aha/garnet/tests/install-verilator.sh
+# #     /aha/garnet/tests/install-verilator.sh
+# # fi
+# # which verilator
+# 
+# 
+# ########################################################################
+# DBG=1
+# hline 72
+# echo now we are in docker. are we in docker\?
+# echo hostname=`hostname`
+# hline 72
+
+#     # Find local garnet home dir $GARNET, based on where this script lives
+#     # Assume this script is $GARNET/tests/test_app/$0
+#     function where_this_script_lives {
+# 
+#       local cmd="$0"    # Is script being executed or sourced?
+#       [ "${BASH_SOURCE[0]}" -ef "$0" ] || cmd="${BASH_SOURCE[0]}" 
+# 
+#       local scriptpath=`realpath $cmd`       # Full path of script e.g. "/foo/bar/baz.sh"
+#       local scriptdir=${scriptpath%/*}       # Script dir e.g. "/foo/bar"
+#       scriptdir=$(cd $scriptdir; pwd)       # Get abs path instead of rel
+#       [ "$scriptdir" == `pwd` ] && scriptdir="."
+#       echo $scriptdir
+#     }
+#     script_home=`where_this_script_lives`
+#     cd $script_home/../..; pwd
+

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -178,7 +178,13 @@ function filter { sed 's/--/|==/' | column -t -s '|' | sed 's/==/--/'; }
 #     app 8x8 tests/fp_pointwise --removed 4 --mu 8
 
 if [ "$SUITE" ]; then
-    type column || yes | apt-get install bsdmainutils || function column { echo; }
+    if ! type column >& /dev/null; then
+        echo "WARNING attempting to install bsdmainutils for 'column' command"
+        if ! (yes | apt-get install bsdmainutils >& /dev/null); then
+            echo "WARNING could not install bsdmainutils; using 'echo' instead of 'column'"
+            function column { echo; }
+        fi
+    fi
     suites_to_print="$SUITE"
     [ "$SUITE" == ALL ] && SUITE=all
     [ "$SUITE" == all ] && suites_to_print="$TEST_SUITES"

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -160,7 +160,6 @@ if [ "$DBG" ]; then hline 72; (echo "$suites" | head); fi
 #     app 8x8 vec_identity       --num-fabric-cols-removed 4 --mu_oc_0 8
 #     app 8x8 tests/fp_pointwise --num-fabric-cols-removed 4 --mu_oc_0 8
 
-type column || yes | apt-get install bsdmainutils || function column { echo; }
 function filter { sed 's/--/|==/' | column -t -s '|' | sed 's/==/--/'; }
 
 ########################################################################
@@ -172,6 +171,7 @@ function filter { sed 's/--/|==/' | column -t -s '|' | sed 's/==/--/'; }
 #     app 8x8 tests/fp_pointwise --removed 4 --mu 8
 
 if [ "$SUITE" ]; then
+    type column || yes | apt-get install bsdmainutils || function column { echo; }
     suites_to_print="$SUITE"
     [ "$SUITE" == ALL ] && SUITE=all
     [ "$SUITE" == all ] && suites_to_print="$TEST_SUITES"

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -160,6 +160,7 @@ if [ "$DBG" ]; then hline 72; (echo "$suites" | head); fi
 #     app 8x8 vec_identity       --num-fabric-cols-removed 4 --mu_oc_0 8
 #     app 8x8 tests/fp_pointwise --num-fabric-cols-removed 4 --mu_oc_0 8
 
+type column || yes | apt-get install bsdmainutils || function column { echo; }
 function filter { sed 's/--/|==/' | column -t -s '|' | sed 's/==/--/'; }
 
 ########################################################################
@@ -268,8 +269,6 @@ fi
 echo '------------------------------------------------------------------------------'
 printf "Ready to do: $bn $app_flags\n\n"
 
-# bookmark
-
 ########################################################################
 # Find which group 'appname' belongs to,
 # e.g. group('apps/pointwise') = 'glb_tests' maybe
@@ -321,27 +320,29 @@ printf "Prepared custom config file /aha/aha/util/regress_tests/$config.py\n\n"
 cat /aha/aha/util/regress_tests/$config.py | sed 's/^/> /'
 echo ""
 
-# BOOKMARK
-
 # I dunno, just run it I guess?
 
-# echo \#\#[group]SETUP
+########################################################################
+# Set up access to requested RTL simulator vcs or verilator
+
 rm -f garnet/garnet.v  # Get rid of old verilog if it exists
 source /aha/bin/activate
 if [ "$SIM" == vcs ]; then
-    echo "PREPARING VCS b/c SIM=$SIM"
+    printf "PREPARING VCS b/c SIM=$SIM\n\n"
     . /cad/modules/tcl/init/bash; module load base; module load vcs
 else
-    echo "PREPARING VERILATOR b/c SIM=$SIM"
+    printf "PREPARING VERILATOR b/c SIM=$SIM\n\n"
     echo /aha/garnet/tests/install-verilator.sh
     /aha/garnet/tests/install-verilator.sh
 fi
 
-(cd /aha/garnet; make clean)  # In case of e.g. CONTAINER_REUSE
+########################################################################
+# Clean up from possible previous run(s) e.g. in case of CONTAINER_REUSE
+# (which no longer exists maybe) and/or maybe just plain old paranoia...
+(cd /aha/garnet; make clean)
 
-# echo \#\#[endgroup]
-# set -x
-# ls -l /aha/aha/util/regress_tests/
+########################################################################
+# Finally: run it!!
 
 if [ "$ZIRCON" == True ]; then
     echo aha regress $config
@@ -350,126 +351,3 @@ else
     echo aha regress $config --no-zircon
     aha regress $config --no-zircon
 fi
-
-exit
-########################################################################
-# TRASH maybe
-
-# ########################################################################
-# # Remaining flags are the app-run command flags e.g.
-# #   '8x8 apps/pointwise --num-fabric-cols-removed 4 --mu_oc_0 8'
-# 
-# # app_flags=("$@")
-# app_flags=`echo "$@"`
-# if [ "$DBG" ]; then
-#     # Arg check, see if args are surviving through all the shenanigans
-#     echo -n ARGS1:; for a in "$@"; do echo -n "'$a' "; done; echo ';'
-#     echo app_flags="'$app_flags'"
-# fi
-# 
-# # ???
-# # echo 1 aha garnet $size ${garnet_flags[@]} --verilog --use_sim_sram --glb_tile_mem_size 128
-
-# ########################################################################
-# # Check on simulator settings
-# if [ "$DBG" ]; then
-#     echo "SIM='$SIM'"; echo "CAD='$CAD'"; echo ""
-# fi
-# 
-# # ########################################################################
-# # # Install verilator if requested
-# # if [ "$SIM" == verilator ]; then
-# #     echo "INSTALLING VERILATOR"
-# #     echo /aha/garnet/tests/install-verilator.sh
-# #     /aha/garnet/tests/install-verilator.sh
-# # fi
-# # which verilator
-# 
-# 
-# ########################################################################
-# DBG=1
-# hline 72
-# echo now we are in docker. are we in docker\?
-# echo hostname=`hostname`
-# hline 72
-
-#     # Find local garnet home dir $GARNET, based on where this script lives
-#     # Assume this script is $GARNET/tests/test_app/$0
-#     function where_this_script_lives {
-# 
-#       local cmd="$0"    # Is script being executed or sourced?
-#       [ "${BASH_SOURCE[0]}" -ef "$0" ] || cmd="${BASH_SOURCE[0]}" 
-# 
-#       local scriptpath=`realpath $cmd`       # Full path of script e.g. "/foo/bar/baz.sh"
-#       local scriptdir=${scriptpath%/*}       # Script dir e.g. "/foo/bar"
-#       scriptdir=$(cd $scriptdir; pwd)       # Get abs path instead of rel
-#       [ "$scriptdir" == `pwd` ] && scriptdir="."
-#       echo $scriptdir
-#     }
-#     script_home=`where_this_script_lives`
-#     cd $script_home/../..; pwd
-
-# ------------------------------------------------------------------------
-#     # Copy local garnet branch to /tmp/deleteme-garnet-$$
-# 
-#     # bookmark
-#     # TODO what happens if we do this using aha with active submodules???
-#     # /bin/rm -rf /tmp/deleteme-garnet-$$; mkdir -p /tmp/deleteme-garnet-$$
-#     # git ls-files | xargs -I{} cp -r --parents {} /tmp/deleteme-garnet-$$
-# 
-#     printf "\n\nBEFORE /aha/garnet/garnet.py=\n"
-#     docker exec $container /bin/bash -c "ls -l /aha/garnet/garnet.py"
-#     echo "BEFORE /aha/aha="
-#     docker exec $container /bin/bash -c "ls -l /aha/aha | egrep -v ^total"
-# 
-#     printf '\n\n\n'
-#     ls -l $tmpdir
-#     printf '\n\n\n'
-# 
-#     printf "\n\nAFTER /aha/garnet/garnet.py=\n"
-#     docker exec $container /bin/bash -c "ls -l /aha/garnet/garnet.py"
-# 
-#     echo "AFTER /aha/aha="
-#     docker exec $container /bin/bash -c "ls -l /aha/aha | egrep -v ^total"
-#     exit
-# 
-#     # echo "##[endgroup]"
-#     # set +x; echo "##[endgroup]"; set -x
-
-
-
-#     # Copy this script to container and run it there
-#     set -x
-#     basename=$(basename $0)
-#     echo "Copy script $0 to container /tmp/$basename"
-#     docker cp $0 $container:/tmp
-#     echo "Run /tmp/$basename in container"
-#     # docker exec $container /tmp/$basename --$SIM $size $appname --cols-removed $FCR --mu_oc_0 $MU
-#     docker exec $container /tmp/$basename $app_flags
-
-# We're gonna see if we can do this with UPDATE
-#     # Override for debugging TODO remove it
-#     docker cp ~/tmpdir/tests.py $container:/aha/aha/util/regress_tests/tests.py
-#     docker cp ~/tmpdir/regress.py $container:/aha/aha/util/regress.py
-
-# TODO test and/or use REUSE_CONTAINER maybe
-# REUSE_CONTAINER=True  # Uncomment for reusable container (for debugging)
-
-#         --reuse*)  REUSE_CONTAINER=True ;;
-#         --keep*)   REUSE_CONTAINER=True ;;
-
-#     # If reuse-container requested, launch and/or use persistent container 'tmp-app-$USER'
-#     if [ "$REUSE_CONTAINER" ]; then
-#         container=tmp-app-$USER-persistent
-#         echo '-------------------------------------------------'
-#         echo "REUSING container '$container'"
-#         echo "Ignore name conflict errors below"
-#         echo '-------------------------------------------------'
-#         function cleanup {
-#             printf '\n\nREMINDER kill docker container $container when done\n\n';
-#         }
-#     else
-
-#     echo '-------------------------------------------------'
-#     echo "NEW CONTAINER '$container'"
-#     echo '-------------------------------------------------'

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -234,17 +234,17 @@ if ! [ "$IN_DOCKER" ]; then
 
         # Copy (cp -r) contents of FROM/SRC repo to a temp dir
         repo=$(echo $UPDATE_SRC | sed 's|/$||; s|.*/||')
-        tmpdir=/tmp/deleteme-update-$repo-$$
+        tmpdir=/tmp/deleteme-update-$repo-$$; clean_src=$tmpdir
         /bin/rm -rf $tmpdir; mkdir -p $tmpdir
         (cd $UPDATE_SRC; git ls-files | xargs -I{} cp -r --parents {} $tmpdir)
 
         # If updating aha repo, skip top level directory so as not to overwrite submodules :(
         [ "$UPDATE_DST" == "/aha/" ]    && UPDATE_DST=/aha/aha
-        [ "$UPDATE_DST" == "/aha/aha" ] && tmpdir=$tmpdir/aha
+        [ "$UPDATE_DST" == "/aha/aha" ] && clean_src=$tmpdir/aha
 
         # Copy contents of temp dir to its final location in the container
         docker exec $container /bin/bash -c "rm -rf $UPDATE_DST"  # Remove old repo
-        docker cp $tmpdir $container:$UPDATE_DST                  # Insert new repo
+        docker cp $clean_src $container:$UPDATE_DST               # Insert new repo
 
         docker exec $container /bin/bash -c "chown -R root:root $UPDATE_DST"
         /bin/rm -rf $tmpdir

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -35,9 +35,6 @@ HELP="
 if [ "$1" == "--help" ]; then echo "$HELP"; exit; fi
 if [ "$1" == "" ];       then echo "$HELP"; exit; fi
 
-# TODO test and/or use REUSE_CONTAINER maybe
-# REUSE_CONTAINER=True  # Uncomment for reusable container (for debugging)
-
 # Unpack the args
 
 # Preserve original flags for later
@@ -88,49 +85,8 @@ done
 
 ########################################################################
 # Find file tests.py
-# TESTS_PY=/aha/aha/util/regress_tests/tests.py
-# test -e $TESTS_PY || TESTS_PY=/nobackup/steveri/github$TESTS_PY
-
-# echo IN CONTAINER NOW\?
-# echo hostname=`hostname`
-# ls -l /aha
-# ls -l /aha/aha
-# ls -l /aha/aha/util
-
-set -x
 TESTS_PY=/aha/aha/util/regress_tests/tests.py
-echo "1 TESTS_PY='$TESTS_PY'"
-ls -l $TESTS_PY
-test -e $TESTS_PY && echo EXISTS || echo NOT EXISTS
-
 test -e $TESTS_PY || TESTS_PY=/nobackup/steveri/github$TESTS_PY
-echo "2 TESTS_PY='$TESTS_PY'"
-ls -l $TESTS_PY
-
-
-
-
-
-set +x
-
-
-
-##############################################################################
-##############################################################################
-##############################################################################
-# # Override for debugging TODO remove it
-# TESTS_PY=/home/steveri/tmpdir/tests.py
-# test -e $TESTS_PY || TESTS_PY=/aha/aha/util/regress_tests/tests.py
-# 
-##############################################################################
-##############################################################################
-##############################################################################
-
-
-########################################################################
-# HLINE e.g. 'hline 5' = "-----\n"
-# Beware how you do this, can be a nightmare for 'set -x' if you get it wrong
-function hline { seq -s- $1 | sed 's/[^-]//g'; }
 
 ########################################################################
 # Parse 'tests.py' to find suite names e.g.
@@ -161,6 +117,8 @@ if [ "$LIST_SUITES" ]; then
     echo "$TEST_SUITES all" | xargs printf "  $bn --show-suite %s\n" | sed 's/,//'
     exit
 fi
+
+function hline { seq -s- $1 | sed 's/[^-]//g'; }  # E.g. 'hline 5' = "-----\n"
 
 ########################################################################
 # Build a COMPACT data structure containing all apps and suites e.g.
@@ -260,37 +218,22 @@ if [ "$SIM" == vcs ]; then
 fi
 
 if ! [ "$IN_DOCKER" ]; then
-# if [ '' ]; then
     echo '-------------------------------------------------'
     echo 'Looks like we are not (yet) in a docker container'
     echo 'What I will do is I will'
     echo '- launch a container using docker image "garnet:latest"'
-    echo '- copy this script to the container'
     echo '- execute the script there'
     echo '-------------------------------------------------'
 
     # Setup
     image=stanfordaha/garnet:latest
     docker pull $image
-    container=deleteme-$USER-aha-test-$$
+    container=deleteme-$USER-run-one-app-$$
     docker run -id --name $container --rm $CAD $image bash
 
     # Trap and kill docker container on exit ('--rm' no workee, but why?)
     function cleanup { printf '\n\n'; set -x; docker kill $container; }
     trap cleanup EXIT
-
-# We're gonna see if we can do this with UPDATE
-#     # Override for debugging TODO remove it
-#     docker cp ~/tmpdir/tests.py $container:/aha/aha/util/regress_tests/tests.py
-#     docker cp ~/tmpdir/regress.py $container:/aha/aha/util/regress.py
-
-# TODO: reuse-container mechanism
-# 
-# container=DELETEME-$USER-apptest-$$
-# [ "$REUSE_CONTAINER" ] && container=deleteme-steveri-testapp-dev
-# # Note for verilator CAD="" else CAD="-v /cad:/cad"
-# # Note this will err if reusing container, but that's okay maybe.
-# docker run -id --name $container --rm $CAD $image bash || echo okay
 
     ########################################################################
     # Update container repo if requested with --update switch, e.g.
@@ -512,3 +455,30 @@ exit
 #     echo "Run /tmp/$basename in container"
 #     # docker exec $container /tmp/$basename --$SIM $size $appname --cols-removed $FCR --mu_oc_0 $MU
 #     docker exec $container /tmp/$basename $app_flags
+
+# We're gonna see if we can do this with UPDATE
+#     # Override for debugging TODO remove it
+#     docker cp ~/tmpdir/tests.py $container:/aha/aha/util/regress_tests/tests.py
+#     docker cp ~/tmpdir/regress.py $container:/aha/aha/util/regress.py
+
+# TODO test and/or use REUSE_CONTAINER maybe
+# REUSE_CONTAINER=True  # Uncomment for reusable container (for debugging)
+
+#         --reuse*)  REUSE_CONTAINER=True ;;
+#         --keep*)   REUSE_CONTAINER=True ;;
+
+#     # If reuse-container requested, launch and/or use persistent container 'tmp-app-$USER'
+#     if [ "$REUSE_CONTAINER" ]; then
+#         container=tmp-app-$USER-persistent
+#         echo '-------------------------------------------------'
+#         echo "REUSING container '$container'"
+#         echo "Ignore name conflict errors below"
+#         echo '-------------------------------------------------'
+#         function cleanup {
+#             printf '\n\nREMINDER kill docker container $container when done\n\n';
+#         }
+#     else
+
+#     echo '-------------------------------------------------'
+#     echo "NEW CONTAINER '$container'"
+#     echo '-------------------------------------------------'

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -396,18 +396,40 @@ exit
 #############################################################################
 # TESTING - Use below script(s) to do exhaustive test of ALL apps in tests.py
 
-# app --show | egrep '^app ' | sort | uniq | shuf > /tmp/alltests
-# (bash <(echo set -x; cat /tmp/alltests)) >& alltests.log &
-# egrep '\+ app' alltests.log
+function testing {
+  # Do not try to execute this as a function!  Cut'n'paste only for now.
 
-# Tools to summarize/monitor test output
-function tabbit { sed 's/--/|==/' | column -t -s '|' | sed 's/==/--/'; }
-function alltest-filter {
-  (egrep '(\+ app |PASS PASS|^Ordt)' $1; echo "+ app ") | awk '
+  # 'tabbit' prevents duplicates e.g.
+  #   app 28x16 conv1                --removed 8 --mu 32
+  #   app 28x16 conv1     --removed 8 --mu 32
+  function tabbit { sed 's/--/|==/' | column -t -s '|' | sed 's/==/--/'; }
+
+  # Build a script
+  nz=`app --show --no-zircon | egrep '^app ' | sort | uniq`
+  zi=`app --show    --zircon | egrep '^app ' | sort | uniq`
+  printf "$zi\n$nz\n" | sed 's/  */ /g' | tabbit | shuf > alltests
+
+  # Run the script
+  (bash <(echo set -x; cat alltests)) >& alltests.log &
+
+  # Tools to summarize/monitor test output
+  function alltest-filter {
+    (egrep '(\+ app |PASS PASS|^Ordt)' $1; echo "+ app ") | awk '
       /^[+]* app/      { n++; app[n]=$0; result[n]="FAIL "; no_date_yet=1 }
       /^Ordt complete/ { if (no_date_yet) {date[n] = substr($(NF-2),1,5); no_date_yet=0} }
       /PASS PASS/      { result[n]="PASS " }
       END              { for (i=1;i<n; i++) print result[i] date[i] " " app[i] }
   ' | sed 's/[+]* app ..update.*aha.aha / app /' # | tabbit
+  }
+  egrep '\+ app' alltests.log
+  alltests-filter alltests.log
+
+
+  # (bash <(echo set -x; printf "$zi\$nz\n")) | shuf > alltests
+  # echo "$nz" | head
+  # echo "$z" | head
+  # printf "$nz\n$z\n" | less -N
+  # printf "$zi\n$nz\n" | sed 's/  */ /g' | less
+  # printf "$zi\n$nz\n" | sed 's/  */ /g' | tabbit | less
+  # # app --show | egrep '^app ' | sort | uniq | shuf > /tmp/alltests
 }
-# alltests-filter alltests.log

--- a/aha/bin/app
+++ b/aha/bin/app
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Undocumented flags for debugging from outside docker
+#   --update /local/aha    /aha/aha     # Update docker repo from local
+#   --update /local/garnet /aha/garnet  # Update docker repo from local
+#   --copy          # Copy working script to docker as /aha/aha/bin/app
+
+# To test: see bottom of file, below
+
 bn=$(basename $0); basename=$bn
 HELP="
   DESCRIPTION:
@@ -372,5 +379,23 @@ if [ "$WAVEFORM" ]; then
     echo "----------------------------------------------------------------"
     ls -l /aha/garnet/tests/test_app/cgra.fsdb
 fi
+exit
 
-    
+#############################################################################
+# TESTING - Use below script(s) to do exhaustive test of ALL apps in tests.py
+
+# app --show | egrep '^app ' | sort | uniq | shuf > /tmp/alltests
+# (bash <(echo set -x; cat /tmp/alltests)) >& alltests.log &
+# egrep '\+ app' alltests.log
+
+# Tools to summarize/monitor test output
+function tabbit { sed 's/--/|==/' | column -t -s '|' | sed 's/==/--/'; }
+function alltest-filter {
+  (egrep '(\+ app |PASS PASS|^Ordt)' $1; echo "+ app ") | awk '
+      /^[+]* app/      { n++; app[n]=$0; result[n]="FAIL "; no_date_yet=1 }
+      /^Ordt complete/ { if (no_date_yet) {date[n] = substr($(NF-2),1,5); no_date_yet=0} }
+      /PASS PASS/      { result[n]="PASS " }
+      END              { for (i=1;i<n; i++) print result[i] date[i] " " app[i] }
+  ' | sed 's/[+]* app ..update.*aha.aha / app /' # | tabbit
+}
+# alltests-filter alltests.log

--- a/aha/bin/docker-bashrc
+++ b/aha/bin/docker-bashrc
@@ -2,6 +2,8 @@ source /aha/bin/activate
 mkdir -p /root/.modules
 source /cad/modules/tcl/init/sh
 
+PATH="$PATH:/aha/aha/bin"
+
 cat << EOF
 
   For pre-compiled Halide gch headers:

--- a/aha/util/app.py
+++ b/aha/util/app.py
@@ -1,0 +1,18 @@
+#   EXAMPLE(S):
+#     aha app 4x2 apps/pointwise
+#     aha app 4x2 tests/fp_pointwise
+#     aha app 4x2 tests/fp_pointwise --waveform
+#     aha app 4x2 tests/fp_pointwise --cols-removed 4 --mu 8
+#     aha app --verilator 4x2 apps/pointwise --cols-removed 4 --mu 8
+
+# For help/details do 'aha app --help'
+
+from pathlib import Path
+import subprocess
+def add_subparser(subparser):
+    parser = subparser.add_parser(Path(__file__).stem, add_help=False)
+    parser.set_defaults(dispatch=dispatch)
+
+def dispatch(args, extra_args=None):
+    print(["/aha/aha/bin/app"] + extra_args)
+    subprocess.call(["/aha/aha/bin/app"] + extra_args)

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -586,18 +586,12 @@ def dispatch(args, extra_args=None):
 
     # No zircon flag (generate default layout)
     if args.no_zircon:
+        print(f"\n\n---- NO-ZIRCON 1 ----\n\n")
         using_matrix_unit = False
         num_fabric_cols_removed = 0
+        mu_oc_0 = 0
 
-    # Check that num_fabric_cols_removed is legal 
-    assert num_fabric_cols_removed % 4 == 0, "ERROR: Number of cols removed must be a multiple of 4"
-    assert num_fabric_cols_removed <= 8, "ERROR: Removing more than 8 columns is not supported yet. Hardware modifications may be necessary to proceed."
-    assert num_fabric_cols_removed <= width - 4, "ERROR: Removing too many columns. There will be no columns left in the CGRA. Please adjust num_fabric_cols_removed and/or CGRA width."
-
-    # Check that OC_0 is legal
-    assert mu_oc_0 <= 2 * (width - num_fabric_cols_removed), "ERROR: OC_0 cannot be greater than 2 * num CGRA cols. Please double-check OC_0, num_fabric_cols_removed, and CGRA width"
-
-    if not(args.no_zircon):
+    else:
         print(f"\033[92mINFO: Using a ZIRCON layout with {num_fabric_cols_removed} fabric columns removed.\033[0m")
         print(f"----ZIRCON LAYOUT INFO----")
         print(f"Tile array width: {width - num_fabric_cols_removed}") 
@@ -606,6 +600,12 @@ def dispatch(args, extra_args=None):
         print(f"MU OC 0: {mu_oc_0}")
         print(f"--------------------------\n")
 
+        # Verify legality of num_fabric_cols_removed, OC_0
+        assert num_fabric_cols_removed % 4 == 0, "ERROR: Number of cols removed must be a multiple of 4"
+        assert num_fabric_cols_removed <= 8, "ERROR: Removing more than 8 columns is not supported yet. Hardware modifications may be necessary to proceed."
+        assert num_fabric_cols_removed <= width - 4, "ERROR: Removing too many columns. There will be no columns left in the CGRA. Please adjust num_fabric_cols_removed and/or CGRA width."
+        assert mu_oc_0 <= 2 * (width - num_fabric_cols_removed), "ERROR: OC_0 cannot be greater than 2 * num CGRA cols. Please double-check OC_0, num_fabric_cols_removed, and CGRA width"
+        
 
     print(f"--- Running regression: {args.config}", flush=True)
     info = []

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -593,9 +593,6 @@ def dispatch(args, extra_args=None):
         mu_oc_0 = 0
 
     else:
-
-    # Check that OC_0 is legal
-
         print(f"\033[92mINFO: Using a ZIRCON layout with {num_fabric_cols_removed} fabric columns removed.\033[0m")
         print(f"----ZIRCON LAYOUT INFO----")
         print(f"Tile array width: {width - num_fabric_cols_removed}")
@@ -610,9 +607,6 @@ def dispatch(args, extra_args=None):
         assert num_fabric_cols_removed <= width - 4, "ERROR: Removing too many columns. There will be no columns left in the CGRA. Please adjust num_fabric_cols_removed and/or CGRA width."
         assert mu_oc_0 <= 2 * (width - num_fabric_cols_removed), "ERROR: OC_0 cannot be greater than 2 * num CGRA cols. Please double-check OC_0, num_fabric_cols_removed, and CGRA width"
         
-
-=======
->>>>>>> master
     print(f"--- Running regression: {args.config}", flush=True)
     info = []
     t = gen_garnet(width, height, dense_only=False, using_matrix_unit=using_matrix_unit, mu_datawidth=mu_datawidth, num_fabric_cols_removed=num_fabric_cols_removed, mu_oc_0=mu_oc_0)

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -4,15 +4,16 @@ class Tests:
         use_custom = False
 
         # Defaults
-
         width, height = 28, 16  # default
-        cols_removed, mu_oc_0 = 8, 32  # zircon defaults
         sparse_tests = []
         glb_tests = []
         glb_tests_fp = []
         resnet_tests = []
         resnet_tests_fp = []
         hardcoded_dense_tests = []
+
+        # Zircon specific parms; 'regress.py --no-zircon' ignores these
+        cols_removed, mu_oc_0 = 8, 32
 
         DRV_supported_tests = [
             "apps/pointwise", "apps/pointwise_mu_io"
@@ -25,7 +26,8 @@ class Tests:
         ]
         # FAST test suite should complete in just a minute or two
         if testname == "fast":
-            width, height = 4, 4
+            width, height = 8, 8,
+            cols_removed, mu_oc_0 = 4, 8  # Ignored if --no-zircon is set
             sparse_tests = [
                 "vec_identity"
             ]
@@ -41,19 +43,6 @@ class Tests:
             ]
             resnet_tests_fp = []
             hardcoded_dense_tests = []
-
-            # New for zircon
-            # TODO need to scrub through remaining tests and add "if zircon" clauses for RV, MB etc.!!!
-            # OR (more hacky) could do "if not zircon delete RV/MB from all groups kinda thing..."
-            # OR give up on no-zircon compatibility
-            if zircon:
-                width, height = 8, 8,
-                cols_removed, mu_oc_0 = 4, 8
-                glb_tests += [
-                    "apps/pointwise_RV_E64",
-                    "apps/pointwise_RV_E64_MB",
-                ]
-
 
         # PR_AHA test suite for aha-repo push/pull
         elif testname == "pr_aha":

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -397,31 +397,21 @@ class Tests:
         self.E64_MB_supported_tests = E64_MB_supported_tests
 
         if use_custom:
-
             # Read a custom suite from external file <testname>.py
-            # E.g. custom config testname='custom4485' to define a 4x2 pointwise run:
-            # 
-            # cat /aha/aha/util/regress_tests/custom4485.py
-            #     width, height = 4, 2"
-            #     glb_tests_fp = [ 'tests/fp_pointwise' ]
-
+            # E.g. if we build a config file '/aha/aha/util/regress_tests/custom4485.py'
+            # "if True:
+            #     width, height = 4, 2
+            #     glb_tests = [ 'tests/pointwise' ]"
+            # then 'aha regress custom4485' would run a 4x2 pointwise test.
             try:
                 # Update self parms w those found in custom config {testname}.py
                 import importlib
                 tmpmodule = importlib.import_module('aha.util.regress_tests.' + testname)
-
-                print('\n\n')
-                print(f"BEFORE self.(w,h)=({self.width},{self.height})")
-                print(f'selfdict={self.__dict__}\n\n')
-
                 self.__dict__.update(tmpmodule.__dict__)
-                print(f"AFTER  self.(w,h)=({self.width},{self.height})\n\n")
-                print(f'tdict={tmpmodule.__dict__}\n\n')
-                print(f'selfdict={self.__dict__}\n\n')
-
             except:
-                # should be more like cannot find config aha/utile/...testname.py or some such
-                raise NotImplementedError(f"Cannot find custom config /aha/aha/util/regress_tests/{testname}.py")
+                raise NotImplementedError(
+                    f"Cannot find custom config /aha/aha/util/regress_tests/{testname}.py"
+                )
 
     def show_suite(self, suite_name='', zircon=True):
         # Dump regression suite contents in compact form e.g. show_suite('fast'):

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -45,6 +45,7 @@ class Tests:
             # New for zircon
             # TODO need to scrub through remaining tests and add "if zircon" clauses for RV, MB etc.!!!
             # OR (more hacky) could do "if not zircon delete RV/MB from all groups kinda thing..."
+            # OR give up on no-zircon compatibility
             if zircon:
                 width, height = 8, 8,
                 cols_removed, mu_oc_0 = 4, 8


### PR DESCRIPTION
I put together a convenient wrapper "app" for running single-app aha regression tests.

I want to make it available to everyone else, so I'm checking it in.

Here's an example of how I use it. First, I do 'app --show' and find the app I want to run.
```
  % /aha/aha/bin/app --show

        # ---------------------------------------
        # REGRESSION SUITE: fast
        app 8x8 vec_identity   --removed 4 --mu 8
        app 8x8 apps/pointwise --removed 4 --mu 8
        ...
```

Then I simply cut'n'paste the disired result line to my command prompt
```
  % /aha/aha/bin/app 8x8 apps/pointwise --removed 4 --mu 8
```
This is what it looks like while it's running
```
    Prepared custom config file /aha/aha/util/regress_tests/config1371.py
    > if True:
    >     width, height = 8, 8
    >     cols_removed, mu_oc_0 = 4, 8
    >     glb_tests = [ 'apps/pointwise' ]

    aha regress config1371
    INFO: Using a ZIRCON layout with 4 fabric columns removed.
    ...
    --- Running regression: config1371
    --- Generating Garnet
    ...
               V C S   S i m u l a t i o n   R e p o r t 
    PASS PASS PASS PASS PASS PASS PASS PASS PASS PASS
```

Also: you don't have to be inside a docker container to run "app," it will launch a container for you if required. So e.g. from kiwi you can do

```
  alias app=/nobackup/steveri/github/aha/aha/bin/app
  app --show | grep pointwise
  app 8x8 apps/pointwise --removed 4 --mu 8
```

Also: e.g. from kiwi/khaki you can tell the wrapper to update a container repo with local changes execution
```
  app 8x8 apps/pointwise --removed 4 --mu 8 --update /nobackup/steveri/github/aha /aha/aha 
```

Also: from kiwi/khaki you can run multiple of these at the same time but beware! It will launch a separate container for each so you could run out of memory pretty quickly...

```
    # Run two apps at once, each in a separate container
    alias app=/nobackup/steveri/github/aha/aha/bin/app
    app 8x8 vec_identity   --removed 4 --mu 8 >& test1.log &
    app 8x8 apps/pointwise --removed 4 --mu 8 >& test2.log &
```
