### PR TITLE
Allow regression steps to run on any available docker agent

### DIFF
--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -49,7 +49,7 @@ d=$BUILDKITE_BUILD_CHECKOUT_PATH;
 
 echo "--- Clone the repo"
 aha_clone=$BUILDKITE_BUILD_CHECKOUT_PATH;
-test -e $aha_clone/.git || git clone https://github.com/StanfordAHA/aha $aha_clone
+git clone https://github.com/StanfordAHA/aha $aha_clone
 cd $aha_clone;
 
 # FIXME things break if DEV_BRANCH not set?
@@ -122,7 +122,6 @@ EOF
     echo "Set metadata buildkite:git:commit to BUILDKITE_MESSAGE=$BUILDKITE_MESSAGE"
     echo "$BUILDKITE_MESSAGE" | buildkite-agent meta-data set buildkite:git:commit
 
-    # buildkite-agent pipeline upload .buildkite/pr_trigger.yml;
     echo "$TRIGGER" | buildkite-agent pipeline upload
     echo "--- CUSTOM CHECKOUT END";
     return
@@ -172,9 +171,7 @@ else
     echo "Skip lengthy submodule initialization"
 fi
 
-# Update submod
-
-# Note PR_REPO_TAIL comes from set-trigfrom-and-reqtype.sh
+# Update submod. Note PR_REPO_TAIL comes from set-trigfrom-and-reqtype.sh
 if [ "$REQUEST_TYPE" == "SUBMOD_PR" ]; then
     c=$AHA_SUBMOD_FLOW_COMMIT  # This is more stable/accurate vs. $BUILDKITE_COMMIT
     echo "--- Update submodule '$PR_REPO_TAIL' w commit '$c'"

--- a/.buildkite/bin/regress-metahooks.sh
+++ b/.buildkite/bin/regress-metahooks.sh
@@ -190,16 +190,10 @@ elif [ "$1" == '--pre-exit' ]; then
     cd $BUILDKITE_BUILD_CHECKOUT_PATH
 
     # Docker will have removed temp/.TEST if all the tests passed
-    echo "+++ [pre-exit] BUILDKITE_COMMAND_EXIT_STATUS = '$BUILDKITE_COMMAND_EXIT_STATUS'"
+    echo "+++ [pre-exit] CHECKING EXIT STATUS"
     if [ "$BUILDKITE_COMMAND_EXIT_STATUS" == 0 ]; then
         test -f temp/.TEST && export BUILDKITE_COMMAND_EXIT_STATUS=13
     fi
-
-    # ~/bin/status-update --force pending
-    # [ "$$FAIL" ] && ~/bin/status-update --force failure || ~/bin/status-update --force success
-    #This is supposed to do the right thing!
-    ~/bin/status-update failure
-
     /bin/rm -rf temp
 
 fi

--- a/.buildkite/bin/regress-metahooks.sh
+++ b/.buildkite/bin/regress-metahooks.sh
@@ -190,10 +190,16 @@ elif [ "$1" == '--pre-exit' ]; then
     cd $BUILDKITE_BUILD_CHECKOUT_PATH
 
     # Docker will have removed temp/.TEST if all the tests passed
-    echo "+++ [pre-exit] CHECKING EXIT STATUS"
+    echo "+++ [pre-exit] BUILDKITE_COMMAND_EXIT_STATUS = '$BUILDKITE_COMMAND_EXIT_STATUS'"
     if [ "$BUILDKITE_COMMAND_EXIT_STATUS" == 0 ]; then
         test -f temp/.TEST && export BUILDKITE_COMMAND_EXIT_STATUS=13
     fi
+
+    # ~/bin/status-update --force pending
+    # [ "$$FAIL" ] && ~/bin/status-update --force failure || ~/bin/status-update --force success
+    #This is supposed to do the right thing!
+    ~/bin/status-update failure
+
     /bin/rm -rf temp
 
 fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,8 +5,10 @@ agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
 env:
   # Default config is "pr_aha"
   CONFIG: ${CONFIG:-pr_aha}
+  NSTEPS:  4  # "Fast" plus three regression steps
 
   # "COMMON" is a dir where we can pass information from one step to another
+  # FIXME or could use 'set-metadata --build', right?
   COMMON: /var/lib/buildkite-agent/builds/DELETEME-$BUILDKITE_BUILD_NUMBER
 
   REGRESS_METAHOOKS: $$COMMON/regress-metahooks.sh
@@ -54,7 +56,6 @@ steps:
             git checkout $$BUILDKITE_COMMIT
         fi
 
-
         # If build was triggered by a pull request, annotate build with
         #    links pointing to pull request on github.
         # Set REQUEST_TYPE to one of "AHA_PUSH", "AHA_PR", or "SUBMOD_PR"
@@ -80,8 +81,7 @@ steps:
 
   commands:
   - echo "+++ BDI PIPELINE.XML COMMANDS BEGIN"
-  # Four steps: (fast, aha1, aha2, aha3) plus also zircon gold-rtl test
-  - NSTEPS=4 .buildkite/bin/regression-steps.sh | buildkite-agent pipeline upload
+  - .buildkite/bin/regression-steps.sh | buildkite-agent pipeline upload
   - echo "--- BDI PIPELINE.XML COMMANDS END"
 
 ########################################################################
@@ -105,20 +105,17 @@ steps:
     
     echo '- Show outcomes from each regression step'
     echo fast outcome:     `buildkite-agent step get "outcome" --step "regress0"`
-    echo regress1 outcome: `buildkite-agent step get "outcome" --step "regress1"`
-    echo regress2 outcome: `buildkite-agent step get "outcome" --step "regress2"`
-    echo regress3 outcome: `buildkite-agent step get "outcome" --step "regress3"`
+    for i in `seq 1 $$((NSTEPS-1))`; do
+        echo regress$$i outcome: `buildkite-agent step get "outcome" --step "regress$$i"`
+    done
 
     echo '- Use FAIL to summarize overall result'
     FAIL=
-    set -x
     [ $(buildkite-agent step get "outcome" --step "docker_gold") == "passed" ] || FAIL=True
     [ $(buildkite-agent step get "outcome" --step "zircon_gold") == "passed" ] || FAIL=True
-
-    [ $(buildkite-agent step get "outcome" --step "regress0") == "passed" ] || FAIL=True
-    [ $(buildkite-agent step get "outcome" --step "regress1") == "passed" ] || FAIL=True
-    [ $(buildkite-agent step get "outcome" --step "regress2") == "passed" ] || FAIL=True
-    [ $(buildkite-agent step get "outcome" --step "regress3") == "passed" ] || FAIL=True
+    for i in `seq 1 $$((NSTEPS-1))`; do
+        [ $(buildkite-agent step get "outcome" --step "regress$$i") == "passed" ] || FAIL=True
+    done
     echo '-- FAIL=$$FAIL'
 
     echo '- Send summary outcome "success" or "failure" to github PR'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,5 @@
-# Agents must have tag hostname=<hostname>
-# And then this will guarantee that all steps run on the same host, see?
-agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
+# Agents must have tag docker=true
+agents: { docker: true }
 
 env:
   # Default config is "pr_aha"


### PR DESCRIPTION
Up til now, regression steps in the `aha-flow` pipeline would build a docker container on either `khaki` or `r8cad-docker`, and the remaining regression steps (fast, pr-aha1, pr-aha2, and pr-aha3) would then have to run on the same server that built the container.

But, as a natural result of the previous code merge, regression steps are no longer bound to run on the same agent that built the docker container.

The code change in this pull request implements that change. So whereas previously the entire regression suite (fast, pr-aha1, pr-aha2, and pr-aha3) would have to run on either khaki or r8cad-docker, the four steps can now be arbitrarily split across the two servers, allocated on demand to whatever is available at the time they are launched.

You can see this behavior in e.g. build 1191, where the `fast` step ran on khaki while `Regress 1,2,3` steps all ran on r8cad-docker: https://buildkite.com/stanford-aha/aha-flow/builds/11991

This was basically a one-line change in `pipeline.yml`. But then I also included a small amount of code cleanup and refactoring.
