### PR TITLE
Regress9 final

### DIFF
--- a/.buildkite/bin/custom-checkout.sh
+++ b/.buildkite/bin/custom-checkout.sh
@@ -32,6 +32,13 @@ echo "+++ BEGIN custom-checkout.sh"
 echo I am in dir `pwd`
 cd /  # Start in a safe place!
 
+# Correct the buildkite message, which may be wrong depending on
+# whether we were triggered from a submodule.
+# Do this right up front b/c metadata gets corrupted sometimes
+# FIXME is this one of those times???
+echo "Set metadata buildkite:git:commit to BUILDKITE_MESSAGE=$BUILDKITE_MESSAGE"
+echo "$BUILDKITE_MESSAGE" | buildkite-agent meta-data set buildkite:git:commit
+
 # should DIE if $BUILDKITE_CLEAN_CHECKOUT==true
 if [ "$BUILDKITE_CLEAN_CHECKOUT" == "true" ]; then
     echo "

--- a/.buildkite/bin/regress-metahooks.sh
+++ b/.buildkite/bin/regress-metahooks.sh
@@ -43,7 +43,7 @@ if [ "$1" == '--pre-command' ]; then
         test -e .git/modules/sam/HEAD || echo OH NO HEAD not found
 
         echo "--- (Re)creating garnet Image"
-        docker build --progress plain . -t "$IMAGE"
+        docker build --progress plain . -t "$IMAGE" --build-arg USE_HTTPS=True
     fi
 
     echo "--- OIT PRE COMMAND HOOK CONTINUES..."

--- a/.buildkite/bin/regress-metahooks.sh
+++ b/.buildkite/bin/regress-metahooks.sh
@@ -16,7 +16,7 @@ if [ "$1" == '--pre-command' ]; then
 
     # In case of e.g. manual retry, original docker image may have been deleted already.
     # This new code below gives us the opportunity to revive the dead image when needed.
-    if ! docker images | grep $TAG; then
+    if ! docker images | grep "$TAG"; then
         echo "OH NO cannot find docker image $IMAGE...I will rebuild it for you"
 
         # Should already be in valid BUILDKITE_BUILD_CHECKOUT_PATH with aha clone
@@ -28,17 +28,18 @@ if [ "$1" == '--pre-command' ]; then
             echo 'Submod pull requests use master branch (sometimes overridden by DEV_BRANCH)'
             # (aha-flow steps is responsible for setting DEV_BRANCH)
             # (https://buildkite.com/stanford-aha/aha-flow/settings/steps)
-            git checkout $DEV_BRANCH || echo no dev branch found, continuing with master
+            git checkout "$DEV_BRANCH" || echo no dev branch found, continuing with master
 
             # Make sure env var BUILDKITE_PULL_REQUEST_REPO is set correctly
-            source $bin/update-pr-repo.sh
+            # xxshellcheck source=/nobackup/steveri/github/aha/.buildkite/bin/update-pr-repo.sh
+            source "$bin/update-pr-repo.sh"
         else
             echo 'Aha push/PR uses pushed branch'
-            git checkout $BUILDKITE_COMMIT
+            git checkout "$BUILDKITE_COMMIT"
         fi
 
         # Checkout and update correct aha branch and submodules
-        source $bin/custom-checkout.sh
+        source "$bin/custom-checkout.sh"
         test -e .git/modules/sam/HEAD || echo OH NO HEAD not found
 
         echo "--- (Re)creating garnet Image"
@@ -47,7 +48,7 @@ if [ "$1" == '--pre-command' ]; then
 
     echo "--- OIT PRE COMMAND HOOK CONTINUES..."
     # Use temp/.TEST to pass fail/success info into and out of docker container
-    echo Renewing `pwd`/temp/.TEST
+    echo Renewing "$(pwd)/temp/.TEST"
     mkdir -p temp; rm -rf temp/.TEST; touch temp/.TEST
 
     # If trigger came from a submod repo, we will do "pr" regressions.
@@ -57,25 +58,49 @@ if [ "$1" == '--pre-command' ]; then
 
     # env file sets REQUEST_TYPE to one of "AHA_PUSH", "AHA_PR", or "SUBMOD_PR"
     # also sets "PR_TAIL_REPO" to requesting submod e.g. "garnet"
-    echo cat /var/lib/buildkite-agent/builds/DELETEME/env-$BUILDKITE_BUILD_NUMBER
-    cat /var/lib/buildkite-agent/builds/DELETEME/env-$BUILDKITE_BUILD_NUMBER
-    source /var/lib/buildkite-agent/builds/DELETEME/env-$BUILDKITE_BUILD_NUMBER
+    echo cat /var/lib/buildkite-agent/builds/DELETEME/env-"$BUILDKITE_BUILD_NUMBER"
+    cat /var/lib/buildkite-agent/builds/DELETEME/env-"$BUILDKITE_BUILD_NUMBER"
+    source /var/lib/buildkite-agent/builds/DELETEME/env-"$BUILDKITE_BUILD_NUMBER"
 
     echo "--- Pass DO_PR info to docker"
     echo "Info gets passed to docker by mounting temp dir as /buildkite omg omg"
     if [ "$REQUEST_TYPE" == "SUBMOD_PR" ]; then
-        echo "+++ SET DO_PR"; mkdir -p temp; touch temp/DO_PR
+        echo ".. SET DO_PR"; mkdir -p temp; touch temp/DO_PR
         if [ "$PR_REPO_TAIL" == "garnet" ]; then
             # Delete .TEST as a sign to skip tests
             echo "+++ Garnet PR detected, so skip redundant regressions"
             rm -rf temp/.TEST
         fi
     else
-        echo "+++ UNSET DO_PR"; /bin/rm -rf temp/DO_PR
+        echo ".. UNSET DO_PR"; /bin/rm -rf temp/DO_PR
     fi
     test -e temp/DO_PR && echo FOO temp/DO_PR exists || echo FOO temp/DO_PR not exists
 
     echo "--- OIT PRE COMMAND HOOK END"
+
+elif [ "$1" == '--exec' ]; then
+
+    echo "--- BEGIN regress-metahooks.sh --exec '$2'"
+
+    # This is designed to be invoked from pipeline.yml, which should provide
+    # necessary env vars including CONTAINER/IMAGE/TAG/CONFIG/REGRESSION_STEP
+
+    docker kill "$CONTAINER" || echo okay
+    docker images; echo "IMAGE=$IMAGE"; echo "TAG=$TAG"
+    docker run -id --name "$CONTAINER" --rm -v /cad:/cad -v ./temp:/buildkite:rw "$IMAGE" bash
+    docker cp /nobackup/zircon/MatrixUnit_sim_sram.v "$CONTAINER":/aha/garnet/MatrixUnit_sim_sram.v
+    docker cp /nobackup/zircon/MatrixUnitWrapper_sim.v "$CONTAINER":/aha/garnet/MatrixUnitWrapper_sim.v
+    docker "exec $CONTAINER" /bin/bash -c "$2"
+    docker "kill $CONTAINER" || echo okay  # Cleanup on aisle FOO
+    echo "--- END regress-metahooks.sh --exec '$2'"
+
+#     cat <<'EOF' > tmp$$  # Single-quotes prevent var expansion etc.
+#     if ! /aha/.buildkite/bin/rtl-goldcheck.sh zircon; then
+#         msg="Zircon gold check FAILED. We don't want to touch Zircon RTL for now."
+#         echo "++ $msg"
+#         echo "$msg" | buildkite-agent annotate --style "error" --context onyx
+#         exit 13
+# EOF
 
 elif [ "$1" == '--commands' ]; then
 
@@ -84,11 +109,13 @@ elif [ "$1" == '--commands' ]; then
     # This is designed to be invoked from pipeline.yml, which should provide
     # necessary env vars including CONTAINER/IMAGE/TAG/CONFIG/REGRESSION_STEP
 
-    docker kill $CONTAINER || echo okay
-    docker images; echo IMAGE=$IMAGE; echo TAG=$TAG
-    docker run -id --name $CONTAINER --rm -e HUGGINGFACE_HUB_TOKEN="$HF_SERVICE_TOKEN" -v /cad:/cad -v ./temp:/buildkite:rw $IMAGE bash
-    docker cp /nobackup/zircon/MatrixUnit_sim_sram.v $CONTAINER:/aha/garnet/MatrixUnit_sim_sram.v
-    docker cp /nobackup/zircon/MatrixUnitWrapper_sim.v $CONTAINER:/aha/garnet/MatrixUnitWrapper_sim.v
+    docker kill "$CONTAINER" || echo okay
+    docker images; echo "IMAGE=$IMAGE"; echo "TAG=$TAG"
+    docker run -id --name "$CONTAINER" --rm \
+           -e HUGGINGFACE_HUB_TOKEN="$HF_SERVICE_TOKEN" \
+           -v /cad:/cad -v ./temp:/buildkite:rw "$IMAGE" bash
+    docker cp /nobackup/zircon/MatrixUnit_sim_sram.v "$CONTAINER":/aha/garnet/MatrixUnit_sim_sram.v
+    docker cp /nobackup/zircon/MatrixUnitWrapper_sim.v "$CONTAINER":/aha/garnet/MatrixUnitWrapper_sim.v
     cat <<'EOF' > tmp$$  # Single-quotes prevent var expansion etc.
 
     if ! test -e /buildkite/.TEST; then
@@ -130,30 +157,20 @@ elif [ "$1" == '--commands' ]; then
       fi
 
     elif [ "$CONFIG" == "pr_aha" ]; then
-
-      # Normal
-      [ "$REGSTEP" == 0 ] && export CONFIG="fast"
-      [ "$REGSTEP" == 1 ] && export CONFIG="pr_aha1 --include-no-zircon-tests"
-      [ "$REGSTEP" == 2 ] && export CONFIG="pr_aha2 --include-no-zircon-tests"
-      [ "$REGSTEP" == 3 ] && export CONFIG="pr_aha3 --include-no-zircon-tests"
-
-      # Prototype
-      # [ "$REGSTEP" == 1 ] && export CONFIG=fast
-      # [ "$REGSTEP" == 2 ] && export CONFIG=fast
-      # [ "$REGSTEP" == 3 ] && export CONFIG=fast
-
-      if [ "$REGSTEP" ] && [ "$CONFIG" == "pr_aha" ]; then
-          echo "ERROR Unassigned repo step '$REGSTEP'"; exit 13
-      else
-          echo "Trigger came from aha repo step '$REGSTEP'; use $CONFIG";
+      # If REGSTEP exists, run the indicated pr_aha subset; e.g. if REGSTEP=1 we run pr_aha1 etc.
+      # Note REGSTEP 0 uses config "fast" instead of e.g. "regress0"
+      if [ "$REGSTEP" ]; then
+          export CONFIG="pr_aha${REGSTEP} --include-no-zircon-tests"
+          [ "$REGSTEP" == 0 ] && export CONFIG="fast"
+          echo "Trigger came from aha-flow step '$REGSTEP', so now CONFIG=$CONFIG";
       fi
 
     else
-      echo "Trigger came from OTHER and (CONFIG != pr_aha): use default and/or config='$CONFIG'"
-
-      # Must restrict to a single slice else they will ALL do the requested CONFIG
+      echo "Trigger came from OTHER, use default and/or config='$CONFIG'"
+      # FIXME what is this and why is it here??? Pretty sure it's outdated/unnecessary :(
       if [ "$REGSTEP" != 1 ]; then
-        DO_AR=False  # I.e. ? don't do aha regressions for this REGSTEP ? right ?
+        echo "Full regressions only run as 'Regress 1'"
+        DO_AR=False
       fi
       CONFIG="$CONFIG --include-no-zircon-tests"
     fi
@@ -177,17 +194,23 @@ elif [ "$1" == '--commands' ]; then
     echo "--- Removing Failure Canary"; rm -rf /buildkite/.TEST
 
 EOF
-    docker exec -e CONFIG=$CONFIG -e REGSTEP=$REGRESSION_STEP $CONTAINER /bin/bash -c "$(cat tmp$$)" || exit 13
-    docker kill $CONTAINER; rm tmp$$  # Cleanup on aisle FOO
+    # Now execute the above script, which was copied to tmp$$
+    # '-e' means 'set environment variable'
+    docker exec \
+           -e CONFIG="$CONFIG" \
+           -e REGSTEP="$REGRESSION_STEP" \
+           "$CONTAINER" /bin/bash -c "$(cat tmp$$)" \
+        || exit 13
+    docker kill "$CONTAINER" || echo okay; rm -f tmp$$  # Cleanup on aisle FOO
     echo "--- END regress-metahooks.sh --commands"
 
 elif [ "$1" == '--pre-exit' ]; then
 
     echo "+++ [pre-exit] KILL CONTAINER $CONTAINER"
-    set -x; docker kill $CONTAINER; set +x
+    set -x; docker kill "$CONTAINER" || echo okay; set +x
 
     # Make sure we are in the right place to reference "temp" subdir
-    cd $BUILDKITE_BUILD_CHECKOUT_PATH
+    cd "$BUILDKITE_BUILD_CHECKOUT_PATH"
 
     # Docker will have removed temp/.TEST if all the tests passed
     echo "+++ [pre-exit] CHECKING EXIT STATUS"
@@ -195,6 +218,4 @@ elif [ "$1" == '--pre-exit' ]; then
         test -f temp/.TEST && export BUILDKITE_COMMAND_EXIT_STATUS=13
     fi
     /bin/rm -rf temp
-
 fi
-

--- a/.buildkite/bin/regress-metahooks.sh
+++ b/.buildkite/bin/regress-metahooks.sh
@@ -43,7 +43,7 @@ if [ "$1" == '--pre-command' ]; then
         test -e .git/modules/sam/HEAD || echo OH NO HEAD not found
 
         echo "--- (Re)creating garnet Image"
-        docker build --progress plain . -t "$IMAGE" --build-arg USE_HTTPS=True
+        ~/bin/buildkite-docker-build --progress plain . -t "$IMAGE"
     fi
 
     echo "--- OIT PRE COMMAND HOOK CONTINUES..."

--- a/.buildkite/bin/regression-steps.sh
+++ b/.buildkite/bin/regression-steps.sh
@@ -299,7 +299,7 @@ exit
 #             dotgit=.git/modules/Halide-to-Hardware; du -shx $$dotgit; /bin/rm -rf $$dotgit
 # 
 #             echo "--- (Re)create garnet Image"
-#             docker build --progress plain . -t "$IMAGE"
+#             docker build --progress plain . -t "$IMAGE" --build-arg USE_HTTPS=True
 # 
 #             echo "--- Pruning Docker Images"
 #             yes | docker image prune -a --filter "until=6h" --filter=label='description=garnet' || true

--- a/.buildkite/bin/regression-steps.sh
+++ b/.buildkite/bin/regression-steps.sh
@@ -124,7 +124,7 @@ elif [ "$next" == "build" ]; then
     buildsteps=$(
       sed '1,/^#BEGIN preamble/d;s/^# //g;/^#END preamble/,$d' "$0"  # Preamble from below
       echo "steps:"
-      # key-exists 'kprep'  || echo "$bdkhaki"
+      key-exists 'kprep'  || echo "$bdkhaki"
       key-exists 'r8prep' || echo "$bdcad"  # FIXME restore before final check-in
     )
     echo "$buildsteps" | buildkite-agent pipeline upload

--- a/.buildkite/bin/regression-steps.sh
+++ b/.buildkite/bin/regression-steps.sh
@@ -124,7 +124,7 @@ elif [ "$next" == "build" ]; then
     buildsteps=$(
       sed '1,/^#BEGIN preamble/d;s/^# //g;/^#END preamble/,$d' "$0"  # Preamble from below
       echo "steps:"
-      key-exists 'kprep'  || echo "$bdkhaki"
+      # key-exists 'kprep'  || echo "$bdkhaki"
       key-exists 'r8prep' || echo "$bdcad"  # FIXME restore before final check-in
     )
     echo "$buildsteps" | buildkite-agent pipeline upload

--- a/.buildkite/bin/regression-steps.sh
+++ b/.buildkite/bin/regression-steps.sh
@@ -299,7 +299,7 @@ exit
 #             dotgit=.git/modules/Halide-to-Hardware; du -shx $$dotgit; /bin/rm -rf $$dotgit
 # 
 #             echo "--- (Re)create garnet Image"
-#             docker build --progress plain . -t "$IMAGE" --build-arg USE_HTTPS=True
+#             ~/bin/buildkite-docker-build --progress plain . -t "$IMAGE"
 # 
 #             echo "--- Pruning Docker Images"
 #             yes | docker image prune -a --filter "until=6h" --filter=label='description=garnet' || true

--- a/.buildkite/bin/regression-steps.sh
+++ b/.buildkite/bin/regression-steps.sh
@@ -1,82 +1,224 @@
 #!/bin/bash
 # This is designed to be called from pipeline.yml
+set -x
+# Uncomment for debugging maybe; e.g. uncomment and then run "$0 build gold 0 1 2" etc.
+# function buildkite-agent { [ "$2" == "upload" ] && cat; }
+# function bkmsg { echo "$1"; }
 
-# Run "fast" app suite as regression step 0.
-# Then run regression configs CONFIG=pr_aha1,2,3..nsteps
+# Run first reg step on command line, then recurse on remaining args.
+# E.g. "$0 build gold 0 1 2" launches the build step(s) and then calls "$0 gold 0 1 2"
+# Regression step 0 = "fast"; steps 1,2,3... = "pr_aha1", "pr_aha2", "pr_aha3"...
 
-# A typical step should look like this:
-# 
-#     - label: "Regress 1"
-#       key: "regress"
-#       env: { REGRESSION_STEP: 0 }
-#       plugins:
-#         - uber-workflow/run-without-clone:
-#     
-#         - improbable-eng/metahook:
-#             pre-command: $BUILD_DOCKER
-#             pre-exit:    $REGRESS_METAHOOKS --pre-exit
-#     
-#       command: $REGRESS_METAHOOKS --commands
+########################################################################
+# HELPER FUNCTIONS
+########################################################################
 
-# Preamble from below
-cat $0 | sed '1,/^#BEGIN preamble/d;s/^# //g;/^#END preamble/,$d'
+# Commands for showing messages on buildkite run page.
+finalmsg=""
+function setstate { buildkite-agent meta-data set "$1" --job "$BUILDKITE_JOB_ID" "$2"; }
+function getstate { buildkite-agent meta-data get "$1" --job "$BUILDKITE_JOB_ID"; }
+function bkmsg { buildkite-agent annotate --context foo --append "$1<br />"; }
+function bkclr {
+    finalmsg="$(date +%H:%M) $finalmsg$1<br />"
+    buildkite-agent annotate --context foo "$finalmsg"
+}
 
-echo "steps:"
+# E.g. "key-exists regress1" fails if there is no step key "regress1" (yet)
+function key-exists {
+    buildkite-agent step get "label" --step "$1" --build "$BUILDKITE_BUILD_ID" >& /dev/null;
+}
 
-cat <<'EOF'
-- label: "Docker for gold test"
-  key: "docker_gold"
-  # Gold test must run on same agent that builds its docker image
-  agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
-  command: echo DONE
-  plugins:
-    - uber-workflow/run-without-clone:
-    - improbable-eng/metahook:
-        pre-command: $BUILD_DOCKER
+########################################################################
+# MAIN
+########################################################################
 
-# - wait: ~
+# Pop next step off arg list e.g. args=(build gold 1 2 3 4 5 6 7 8 9)
+# => next="build", args=(gold 1 2 3 4 5 6 7 8 9)
+next="$1"; if ! [ "$next" ]; then echo DONE; exit; fi
+shift; bkmsg "Processing arg next='$next'"
 
-- label: "Zircon Gold"
-  depends_on: "docker_gold"
-  # Gold test must run on same agent that builds its docker image
-  # FIXME but what if this step fails and we want to retry???
-  agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
-  key: "zircon_gold"
-  plugins:
-    - uber-workflow/run-without-clone:
-    - docker#v3.2.0:
-        image: garnet:aha-flow-build-${BUILDKITE_BUILD_NUMBER}
-        volumes: ["/cad/:/cad"]
-        shell:   ["/bin/bash", "-e", "-c"]
-        mount-checkout: false
-  commands: |
-    echo "/aha/.buildkite/bin/rtl-goldcheck.sh zircon"
-    if ! /aha/.buildkite/bin/rtl-goldcheck.sh zircon; then
-        msg="Zircon gold check FAILED. We don't want to touch Zircon RTL for now."
-        echo "++ $$msg"
-        echo "$$msg" | buildkite-agent annotate --style "error" --context onyx
-        exit 13
+#------------------------------------------------------------------------------
+if [ "$next" == "--cleanup" ]; then
+    echo '+++ Step outcomes'
+
+    # Cleanup step summarizes outcomes of all previous steps
+    # and sends final status to any waiting PRs
+
+    # Set FAIL if indicated step failed
+    FAIL=; function cleanup {
+        echo "$1": "$(buildkite-agent step get outcome --step "$2")"
+        echo "$1": "$(buildkite-agent step get outcome --step "$2")"
+        [ "$(buildkite-agent step get outcome --step "$2")" == "passed" ] || FAIL=True
+    }
+
+    # For each step indicated in command line, check that step for failure
+    for step in "$@"; do
+        if [ "$step" == "build" ]; then
+            cleanup 'khaki prep' kprep
+            cleanup 'r8cad prep' r8prep
+
+        elif [ "$step" == "gold" ]; then
+            cleanup 'Zircon Gold' zircon_gold
+
+        else
+            # Only remaining choice is that step is a single digit 0-9
+            [ "$step" == 0 ] && label="Fast" || label="Regress $i"
+            cleanup "$label" regress"$step"
+        fi
+    done
+    echo "-- FAIL=$FAIL"
+
+    # Note, /home/buildkite-agent/bin/status-update must exist on agent machine
+    # Also see ~steveri/bin/status-update on kiwi
+    echo '- Send summary outcome "success" or "failure" to github PR'
+    if [ "$FAIL" ]; then
+        ~/bin/status-update --force failure
+    else
+        ~/bin/status-update --force success
+    fi
+    echo '- Clean up your mess'
+
+#------------------------------------------------------------------------------
+elif [ "$next" == "build" ]; then
+
+    # FIXME this launches two build steps at the same time; the
+    # possibility exists that both call regression-steps.sh at same time.
+    # That would be trouble for our new chaining approach, yes?
+    # Need flock? something simpler/smarter?
+
+    # Early-out if these steps have already been launched!
+    if key-exists 'kprep'; then
+        if key-exists 'r8prep'; then
+            echo "Steps 'kprep' and 'r8prep' already exist in pipeline. So. Nothing to do!"; exit 0
+        fi
     fi
 
-EOF
+    # Build the two individual build steps, one for each agent :)
+    bdkhaki=$(
+  cat << '    EOF' | sed 's/^    //' | sed "s/ARGS/$*/"
+    - label: "khaki prep"
+      key: "kprep"
+      agents: { hostname: khaki }
+      # Launch next step if/when build is complete
+      command: .buildkite/bin/regression-steps.sh ARGS
+      plugins:
+        - uber-workflow/run-without-clone:
+        - improbable-eng/metahook:
+            pre-command: $BUILD_DOCKER
+    EOF
+)
+    bdcad=$(
+  cat << '    EOF' | sed 's/^    //' | sed "s/ARGS/$*/"
+    - label: "r8cad prep"
+      key: "r8prep"
+      agents: { hostname: r8cad-docker }
+      # Launch next step if/when build is complete
+      command: .buildkite/bin/regression-steps.sh ARGS
+      plugins:
+        - uber-workflow/run-without-clone:
+        - improbable-eng/metahook:
+            pre-command: $BUILD_DOCKER
+    EOF
+)
+    # Package the two steps into one bundle, then upload the bundle
+    buildsteps=$(
+      sed '1,/^#BEGIN preamble/d;s/^# //g;/^#END preamble/,$d' "$0"  # Preamble from below
+      echo "steps:"
+      key-exists 'kprep'  || echo "$bdkhaki"
+      key-exists 'r8prep' || echo "$bdcad"  # FIXME restore before final check-in
+    )
+    echo "$buildsteps" | buildkite-agent pipeline upload
 
-for i in `seq 0 $((NSTEPS-1))`; do
+#------------------------------------------------------------------------------
+elif [ "$next" == "gold" ]; then
+
+    # Upload gold step, wait for it to start running (i.e. "launch")
+
+    # This is one way how you can skip a step for e.g. debugging
+    # exec "$0" "$@"  # FIXME Skip gold for now FIXME restore before final check-in
+
+    # Early-out if step has already been launched!
+    key='zircon_gold'; if key-exists $key; then
+        echo "Step '$key' already exists in pipeline. So. Nothing to do!"; exit 0
+    fi
+    goldstep=$(
+  sed '1,/^#BEGIN preamble/d;s/^# //g;/^#END preamble/,$d' "$0"  # Preamble from below
+  cat << '    EOF' | sed 's/^    //' | sed "s/ARGS/$*/"
+    steps:
+    - label: "Zircon Gold"
+      key: "zircon_gold"
+      command: |
+        if ! $REGRESS_METAHOOKS --exec '/aha/.buildkite/bin/rtl-goldcheck.sh zircon'; then
+            msg="Zircon gold check FAILED. We don't want to touch Zircon RTL for now."
+            echo "--- $$msg"
+            echo "$$msg" | buildkite-agent annotate --style "error" --context onyx
+            exit 13
+        else echo "--- $$msg Zircon gold check PASSED"
+        fi
+        .buildkite/bin/regression-steps.sh ARGS  # Chain to next step
+      plugins:
+        - uber-workflow/run-without-clone:
+        - improbable-eng/metahook:
+            pre-command: $BUILD_DOCKER cd . ; $REGRESS_METAHOOKS --pre-command
+    EOF
+)
+# setstate launch-state READY  # FIXME do we use this??
+echo "$goldstep" | buildkite-agent pipeline upload
+
+
+# BOOKMARK
+#------------------------------------------------------------------------------
+else
+    # "$next" must be "build", "gold" or a single digit 0-9
+    # Since we already processed "build and "gold" above, that leaves 0-9
+    i=$next  # Should be one of {0,1,2,3,4,5,6,7,8,9}
+
+    # Early-out if step has already been launched!
+    key="regress$i"; if key-exists "$key"; then
+        echo "Step '$key' already exists in pipeline. So. Nothing to do!"; exit 0
+    fi
+
+    # Fairness algorithm (CONCURRENCY=4) means at most four regression steps can run at a time
+CONCURRENCY="
+  concurrency: $MAX_AGENTS  # Limit long-running jobs to at most <MAX> at a time.
+  concurrency_group: "aha-flow-${BUILDKITE_BUILD_ID}"
+"
+    # Launch next step
+    # Each new step uploads only after previous step has started running.
     [ "$i" == 0 ] && label="Fast" || label="Regress $i"
-    cat <<EOF
-- label: "$label"
-  key: "regress$i"
-  env: { REGRESSION_STEP: $i }
-  command: \$REGRESS_METAHOOKS --commands
-  plugins:
-    - uber-workflow/run-without-clone:
-    - improbable-eng/metahook:
-        pre-command: \$BUILD_DOCKER cd . ; \$REGRESS_METAHOOKS --pre-command
-        pre-exit:    \$REGRESS_METAHOOKS --pre-exit
 
+    # setstate launch-state READY
+    # bkmsg "$label READY TO LAUNCH"
+
+    (sed '1,/^#BEGIN preamble/d;s/^# //g;/^#END preamble/,$d' "$0"
+    cat <<EOF | sed 's/^    //' | sed "s/ARGS/$*/"
+    steps:
+    - label: "$label"
+      # agents: { hostname: khaki }  # Can uncomment for debugging etc.
+      key: "regress$i"
+      env: { REGRESSION_STEP: $i }
+      command: |
+        .buildkite/bin/regression-steps.sh ARGS  # Chain to next step
+        \$REGRESS_METAHOOKS --commands
+      plugins:
+        - uber-workflow/run-without-clone:
+        - improbable-eng/metahook:
+            pre-command: |
+                RSTEP=$i
+                \$BUILD_DOCKER
+                cd .
+                \$REGRESS_METAHOOKS --pre-command
+            pre-exit: |
+                \$REGRESS_METAHOOKS --pre-exit
 EOF
-done
+    [ "$i" != 0 ] && echo "$CONCURRENCY"
+    echo "") | buildkite-agent pipeline upload
+fi
 
+#------------------------------------------------------------------------------
+exit
 
+#------------------------------------------------------------------------------
 #BEGIN preamble
 # env:
 #   # This script allows retries even after original collateral is gone...
@@ -98,6 +240,8 @@ done
 #         echo curl $$remote/.buildkite/bin/regress-metahooks.sh -o $REGRESS_METAHOOKS
 #         curl $$remote/.buildkite/bin/regress-metahooks.sh -o $REGRESS_METAHOOKS
 #         chmod +x $REGRESS_METAHOOKS
+#         curl $$remote/.buildkite/bin/regression-steps.sh -o .buildkite/bin/regression-steps.sh
+#         chmod +x .buildkite/bin/regression-steps.sh
 #     fi
 # 
 #     # If docker image is gone, e.g. in case of retry maybe, we'll have to rebuild it
@@ -115,6 +259,9 @@ done
 #         if ! [ `docker images -q $IMAGE` ]; then
 #             echo "+++ CANNOT FIND DOCKER IMAGE '$IMAGE'"
 #             echo "And I have the lock so...guess I am the one who will be (re)building it"
+# 
+#             # Change step label to reflect docker build DB
+#             buildkite-agent step update "label" " + DB($(hostname))" --append
 # 
 #             # Remove docker images older than one day
 #             echo "--- Cleanup old docker images"
@@ -164,5 +311,11 @@ done
 #     # cd .  # Got weird error without this...??
 #     # set -x; $REGRESS_METAHOOKS --pre-command
 # 
+#     function setstate { buildkite-agent meta-data set $$1 --job $BUILDKITE_JOB_ID $$2; }
+#     function bkmsg    { buildkite-agent annotate --context foo --append "$$1<br />"; }
+# 
+#     setstate image-exists TRUE
+#     setstate launch-state LAUNCHED
+#     bkmsg "BD: $$BUILDKITE_LABEL LAUNCHED"
 # 
 #END preamble

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,12 @@ agents: { docker: true }
 env:
   # Default config is "pr_aha"
   CONFIG: ${CONFIG:-pr_aha}
-  NSTEPS:  4  # "Fast" plus three regression steps
+
+  # RSTEPS: "build gold 0 1 2 3 4 5 6 7 8 9"
+  # RSTEPS: "build gold 0 1 2 3"
+  RSTEPS: "build gold 0 1 2 3 4 5 6 7 8 9"
+
+  MAX_AGENTS: 4  # How many agents do we get to use for regression steps?
 
   # "COMMON" is a dir where we can pass information from one step to another
   # FIXME or could use 'set-metadata --build', right?
@@ -80,7 +85,7 @@ steps:
 
   commands:
   - echo "+++ BDI PIPELINE.XML COMMANDS BEGIN"
-  - .buildkite/bin/regression-steps.sh | buildkite-agent pipeline upload
+  - .buildkite/bin/regression-steps.sh $RSTEPS
   - echo "--- BDI PIPELINE.XML COMMANDS END"
 
 ########################################################################
@@ -96,37 +101,4 @@ steps:
   plugins:
     - uber-workflow/run-without-clone:
 
-  command: |
-
-    echo '- Show outcomes from gold step(s)'
-    echo docker_gold outcome: `buildkite-agent step get "outcome" --step "docker_gold"`
-    echo zircon_gold outcome: `buildkite-agent step get "outcome" --step "zircon_gold"`
-
-    echo '- Show outcomes from each regression step'
-    echo fast outcome:     `buildkite-agent step get "outcome" --step "regress0"`
-    for i in `seq 1 $$((NSTEPS-1))`; do
-        echo regress$$i outcome: `buildkite-agent step get "outcome" --step "regress$$i"`
-    done
-
-    echo '- Use FAIL to summarize overall result'
-    FAIL=
-    [ $(buildkite-agent step get "outcome" --step "docker_gold") == "passed" ] || FAIL=True
-    [ $(buildkite-agent step get "outcome" --step "zircon_gold") == "passed" ] || FAIL=True
-    for i in `seq 1 $$((NSTEPS-1))`; do
-        [ $(buildkite-agent step get "outcome" --step "regress$$i") == "passed" ] || FAIL=True
-    done
-    echo '-- FAIL=$$FAIL'
-
-    echo '- Send summary outcome "success" or "failure" to github PR'
-    # Note, /home/buildkite-agent/bin/status-update must exist on agent machine
-    # Also see ~steveri/bin/status-update on kiwi
-    [ "$$FAIL" ] && ~/bin/status-update --force failure || ~/bin/status-update --force success
-
-    echo '- Clean up your mess'
-    test -e $REGRESS_METAHOOKS && rm $REGRESS_METAHOOKS || echo okay
-
-    # No don't do this. Excludes ability to rerun etc.
-    # Also, COMMON is generally not very big.
-    # ~Also, code above will eliminate DELETEME files older than one week.~ (I don't think so...?)
-    # test -d $COMMON && rmdir $COMMON || echo okay
-    # /bin/rm -f /var/lib/buildkite-agent/builds/DELETEME/env-$BUILDKITE_BUILD_NUMBER
+  command: .buildkite/bin/regression-steps.sh --cleanup $RSTEPS

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,9 +5,8 @@ env:
   # Default config is "pr_aha"
   CONFIG: ${CONFIG:-pr_aha}
 
-  # RSTEPS: "build gold 0 1 2 3 4 5 6 7 8 9"
-  # RSTEPS: "build gold 0 1 2 3"
-  RSTEPS: "build gold 0 1 2 3 4 5 6 7 8 9"
+  # RSTEPS: "gold 0 1 2 3"  # gold + fast + regress 1-3, skipping the build stage
+  RSTEPS: "build gold 0 1 2 3 4 5 6 7 8 9"  # gold + fast + regress 1-9
 
   MAX_AGENTS: 4  # How many agents do we get to use for regression steps?
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,14 +25,11 @@ jobs:
 
     - name: Publish Docker image
       uses: elgohr/Publish-Docker-Github-Action@2.12
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-        FOO: BARBAZZY
-        BAR: BRAMZLE
+      # env:  GITHUB_TOKEN: ${{ github.token }}
+      env:  GITHUB_TOKEN: XYZ
       with:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        buildargs: GITHUB_TOKEN,FOO,BAR
-        buildoptions: "--build-arg BAZ=GOOF"
+        buildargs: GITHUB_TOKEN
         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,19 +18,44 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - name: Delete clockwork and halide metadata
       run: |
         du -shx     .git/modules/clockwork .git/modules/Halide-to-Hardware
         /bin/rm -rf .git/modules/clockwork .git/modules/Halide-to-Hardware
 
-    - name: Publish Docker image
-      uses: elgohr/Publish-Docker-Github-Action@2.12
-      env:
-        GTOKEN: ${{ github.token }}
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v2
       with:
-        name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        # buildargs: GITHUB_TOKEN
-        buildoptions: "--secret id=gtoken,env=GTOKEN"
-        cache: false
+
+    - name: Build and Publish Docker Image
+      run: |
+        echo "${{ github.token }}" > my_secret.txt
+        docker buildx build \
+          --secret id=gtoken,src=my_secret.txt \
+          --push \
+          .
+
+
+#           --push \
+#           --tag your-dockerhub-user/your-image:latest \
+#           .
+
+
+
+
+#     - name: Publish Docker image
+#       uses: elgohr/Publish-Docker-Github-Action@2.12
+#       env:
+#         GTOKEN: ${{ github.token }}
+#       with:
+#         name: stanfordaha/garnet
+#         username: ${{ secrets.DOCKER_USERNAME }}
+#         password: ${{ secrets.DOCKER_PASSWORD }}
+#         # buildargs: GITHUB_TOKEN
+#         buildoptions: "--secret id=gtoken,env=GTOKEN"
+#         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -32,7 +32,5 @@ jobs:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        buildargs:
-          GITHUB_TOKEN=${{ github.token }}
-          FOO=BARBAZ
+        buildargs: GITHUB_TOKEN,FOO
         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,12 +25,12 @@ jobs:
 
     - name: Publish Docker image
       uses: elgohr/Publish-Docker-Github-Action@2.12
-      # env:
-      #   GITHUB_TOKEN: ${{ github.token }}
+      env:
+        GTOKEN: ${{ github.token }}
       with:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         # buildargs: GITHUB_TOKEN
-        buildoptions: "--secret id GIT_AUTH_TOKEN=${{ github.token }}"
+        buildoptions: "--secret id=gtoken,env=GTOKEN"
         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,11 +25,12 @@ jobs:
 
     - name: Publish Docker image
       uses: elgohr/Publish-Docker-Github-Action@2.12
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+      # env:
+      #   GITHUB_TOKEN: ${{ github.token }}
       with:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        buildargs: GITHUB_TOKEN
+        # buildargs: GITHUB_TOKEN
+        buildoptions: "--secret id GIT_AUTH_TOKEN=${{ github.token }}"
         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,8 +25,9 @@ jobs:
 
     - name: Publish Docker image
       uses: elgohr/Publish-Docker-Github-Action@2.12
-      # env:  GITHUB_TOKEN: ${{ github.token }}
-      env:  GITHUB_TOKEN: XYZ
+      env:
+        # GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: xyz
       with:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -34,4 +34,5 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         buildargs: GITHUB_TOKEN,FOO,BAR
+        buildoptions: "--build-args BAZ=GOOF"
         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -27,10 +27,11 @@ jobs:
       uses: elgohr/Publish-Docker-Github-Action@2.12
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        FOO: BARBAZ
+        FOO: BARBAZZY
+        BAR: BRAMZLE
       with:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        buildargs: GITHUB_TOKEN,FOO
+        buildargs: GITHUB_TOKEN,FOO,BAR
         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,9 +25,14 @@ jobs:
 
     - name: Publish Docker image
       uses: elgohr/Publish-Docker-Github-Action@2.12
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        FOO: BARBAZ
       with:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        buildargs: GITHUB_TOKEN=${{ github.token }}
+        buildargs:
+          GITHUB_TOKEN=${{ github.token }}
+          FOO=BARBAZ
         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -34,5 +34,5 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         buildargs: GITHUB_TOKEN,FOO,BAR
-        buildoptions: "--build-args BAZ=GOOF"
+        buildoptions: "--build-arg BAZ=GOOF"
         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -26,8 +26,7 @@ jobs:
     - name: Publish Docker image
       uses: elgohr/Publish-Docker-Github-Action@2.12
       env:
-        # GITHUB_TOKEN: ${{ github.token }}
-        GITHUB_TOKEN: xyz
+        GITHUB_TOKEN: ${{ github.token }}
       with:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -38,25 +38,4 @@ jobs:
         docker buildx build \
           --secret id=gtoken,src=my_secret.txt \
           --tag stanfordaha/garnet:latest \
-          --push \
-          .
-
-
-#           --push \
-#           --tag your-dockerhub-user/your-image:latest \
-#           .
-
-
-
-
-#     - name: Publish Docker image
-#       uses: elgohr/Publish-Docker-Github-Action@2.12
-#       env:
-#         GTOKEN: ${{ github.token }}
-#       with:
-#         name: stanfordaha/garnet
-#         username: ${{ secrets.DOCKER_USERNAME }}
-#         password: ${{ secrets.DOCKER_PASSWORD }}
-#         # buildargs: GITHUB_TOKEN
-#         buildoptions: "--secret id=gtoken,env=GTOKEN"
-#         cache: false
+          --push .

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -37,6 +37,7 @@ jobs:
         echo "${{ github.token }}" > my_secret.txt
         docker buildx build \
           --secret id=gtoken,src=my_secret.txt \
+          --tag stanfordaha/garnet:latest \
           --push \
           .
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -29,4 +29,5 @@ jobs:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        buildargs: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         cache: false

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -29,5 +29,5 @@ jobs:
         name: stanfordaha/garnet
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        buildargs: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        buildargs: GITHUB_TOKEN=${{ github.token }}
         cache: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
         submodules: recursive
 
     - name: Build Docker Image
-      run: docker build . -t testing --secret id GIT_AUTH_TOKEN=${{ github.token }}
+      run: GTOKEN=${{ github.token }} docker build . -t testing --secret id=gtoken,env=GTOKEN
 
     - name: Run Integration Tests
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,10 +31,14 @@ jobs:
     - name: Build Docker Image
       run: docker build . -t testing
     - name: Run Integration Tests
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        FOO: BARBAZ
       run: |
         docker run --name test --rm \
             -e HUGGINGFACE_HUB_TOKEN=${{ secrets.HF_SERVICE_TOKEN }} \
             -e GITHUB_TOKEN=${{ github.token }} \
+            -e FOO=BARBAZ \
             -it -d testing bash
         docker exec test pip freeze
         docker exec test bash -c "source /aha/bin/activate && aha garnet --width 4 --height 2 --verilog --use_sim_sram"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,17 +29,15 @@ jobs:
       with:
         submodules: recursive
     - name: Build Docker Image
-      run: docker build . -t testing
-    - name: Run Integration Tests
       env:
         GITHUB_TOKEN: ${{ github.token }}
         FOO: BARBAZ
+      run: docker build . -t testing --build-arg BAR=BRAMBLE
+    - name: Run Integration Tests
       run: |
         printenv
         docker run --name test --rm \
             -e HUGGINGFACE_HUB_TOKEN=${{ secrets.HF_SERVICE_TOKEN }} \
-            -e GITHUB_TOKEN=${{ github.token }} \
-            -e FOO=BARBAZ \
             -it -d testing bash
         docker exec test pip freeze
         docker exec test bash -c "source /aha/bin/activate && aha garnet --width 4 --height 2 --verilog --use_sim_sram"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
         submodules: recursive
 
     - name: Build Docker Image
-      run: docker build . -t testing --build-arg GITHUB_TOKEN=${{ github.token }}
+      run: docker build . -t testing --secret id GIT_AUTH_TOKEN=${{ github.token }}
 
     - name: Run Integration Tests
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,10 +32,14 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
         FOO: BARBAZ
-      run: docker build . -t testing --build-arg BAR=BRAMBLE
-    - name: Run Integration Tests
       run: |
         printenv
+        docker build . -t testing \
+          --build-arg GITHUB_TOKEN=${{ github.token }} \
+          --build-arg FOO=BARBAZ \
+          --build-arg BAR=BRAMBLE
+    - name: Run Integration Tests
+      run: |
         docker run --name test --rm \
             -e HUGGINGFACE_HUB_TOKEN=${{ secrets.HF_SERVICE_TOKEN }} \
             -it -d testing bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,6 +35,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
         FOO: BARBAZ
       run: |
+        printenv
         docker run --name test --rm \
             -e HUGGINGFACE_HUB_TOKEN=${{ secrets.HF_SERVICE_TOKEN }} \
             -e GITHUB_TOKEN=${{ github.token }} \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,24 +28,17 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+
     - name: Build Docker Image
-      env:
-        GITHUB_TOKEN: XYZ
-        FOO: BARBAZ
-      run: |
-        printenv
-        docker build . -t testing \
-          --build-arg GITHUB_TOKEN=${{ github.token }} \
-          --build-arg FOO=BARBAZ \
-          --build-arg BAR=BRAMBLE
+      run: docker build . -t testing --build-arg GITHUB_TOKEN=${{ github.token }}
+
     - name: Run Integration Tests
       run: |
-        docker run --name test --rm \
-            -e HUGGINGFACE_HUB_TOKEN=${{ secrets.HF_SERVICE_TOKEN }} \
-            -it -d testing bash
+        docker run --name test --rm -e HUGGINGFACE_HUB_TOKEN=${{ secrets.HF_SERVICE_TOKEN }} -it -d testing bash
         docker exec test pip freeze
         docker exec test bash -c "source /aha/bin/activate && aha garnet --width 4 --height 2 --verilog --use_sim_sram"
         docker exec test test -e /aha/garnet/garnet.v
+
     - name: Notify Owners on Failure
       if: github.event_name == 'pull_request' && failure()
       uses: actions/github-script@0.4.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,7 +32,10 @@ jobs:
       run: docker build . -t testing
     - name: Run Integration Tests
       run: |
-        docker run --name test --rm -e HUGGINGFACE_HUB_TOKEN=${{ secrets.HF_SERVICE_TOKEN }} -it -d testing bash
+        docker run --name test --rm \
+            -e HUGGINGFACE_HUB_TOKEN=${{ secrets.HF_SERVICE_TOKEN }} \
+            -e GITHUB_TOKEN=${{ github.token }} \
+            -it -d testing bash
         docker exec test pip freeze
         docker exec test bash -c "source /aha/bin/activate && aha garnet --width 4 --height 2 --verilog --use_sim_sram"
         docker exec test test -e /aha/garnet/garnet.v

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
         submodules: recursive
     - name: Build Docker Image
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: XYZ
         FOO: BARBAZ
       run: |
         printenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ LABEL description="garnet"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG FOO
 ARG BAR
+ARG BAZ
+ARG GITHUB_TOKEN
 
 RUN apt-get update && \
     apt-get install -y \
@@ -108,14 +111,17 @@ COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 
 # BAD
 # RUN cd /aha && git clone ssh://git@github.com/StanfordAHA/voyager.git voyager && 
+# git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git
+# git clone https://github.com/StanfordAHA/voyager.git voyager && \
+#
 
 # also bad
 RUN cd /aha && \
   echo GT=$GITHUB_TOKEN | cut -b 1-20 && \
-  echo HHT=$HUGGINGFACE_HUB_TOKEN | cut -b 1-20 && \
   echo FOO=$FOO && \
   echo BAR=$BAR && \
-  git clone https://github.com/StanfordAHA/voyager.git voyager && \
+  echo BAZ=$BAZ && \
+  git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git && \
   cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \
   mv .git/ /aha/.git/modules/voyager/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,8 @@ COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 # also bad
 RUN cd /aha && \
   echo GT=$GITHUB_TOKEN | cut -b 1-20 && \
+  echo HHT=$HUGGINGFACE_HUB_TOKEN | cut -b 1-20 && \
+  echo FOO=$FOO && \
   git clone https://github.com/StanfordAHA/voyager.git voyager && \
   cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,6 @@ LABEL description="garnet"
 ENV DEBIAN_FRONTEND=noninteractive
 # ARG GITHUB_TOKEN
 
-# USE_HTTPS set by regress-metahooks.sh "docker build --build-arg USE_HTTPS=True"
-# It tells us to use http protocol for git clone voyager
-# FIXME I'm sure there are ten better ways to do this :(
-ARG USE_HTTPS
-
 RUN apt-get update && \
     apt-get install -y \
         build-essential software-properties-common && \
@@ -110,12 +105,7 @@ RUN source bin/activate && \
 # Voyager 1 - clone voyager
 COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 
-#   if [ "$USE_HTTPS" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
-#   else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
-#  git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager && \
-# git clone ssh://git@github.com/StanfordAHA/voyager.git voyager
-
-# GIT_AUTH_TOKENS maybe
+# Use token provided by docker-build `--secrets` to clone voyager
 RUN --mount=type=secret,id=gtoken \
   cd /aha && \
   git clone https://$(cat /run/secrets/gtoken)@github.com:/StanfordAHA/voyager.git voyager && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,11 +117,12 @@ COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 
 # also bad
 RUN cd /aha && \
+  printenv && \
   echo GT=$GITHUB_TOKEN | cut -b 1-20 && \
   echo FOO=$FOO && \
   echo BAR=$BAR && \
   echo BAZ=$BAZ && \
-  if [ "$FOO" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
+  if [ "$BUILDKITE" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
   else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
   cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,8 @@ RUN cd /aha && \
   echo FOO=$FOO && \
   echo BAR=$BAR && \
   echo BAZ=$BAZ && \
-  git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git && \
+  if [ "$FOO" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
+  else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
   cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \
   mv .git/ /aha/.git/modules/voyager/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,10 +118,7 @@ COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 # also bad
 RUN cd /aha && \
   printenv && \
-  echo GT=$GITHUB_TOKEN | cut -b 1-20 && \
-  echo FOO=$FOO && \
-  echo BAR=$BAR && \
-  echo BAZ=$BAZ && \
+  echo GT=$GITHUB_TOKEN && \
   if [ "$BUILDKITE" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
   else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
   cd /aha/voyager && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,10 +112,12 @@ COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 
 #   if [ "$USE_HTTPS" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
 #   else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
+#  git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager && \
 
 
+# GIT_AUTH_TOKENS maybe
 RUN cd /aha && \
-  git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager && \
+  git clone https://github.com:/StanfordAHA/voyager.git voyager && \
   cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \
   mv .git/ /aha/.git/modules/voyager/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,6 @@ FROM docker.io/ubuntu:20.04
 LABEL description="garnet"
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-ARG FOO
-ARG BAR
-ARG BAZ
 ARG GITHUB_TOKEN
 
 RUN apt-get update && \
@@ -109,16 +105,7 @@ RUN source bin/activate && \
 # Voyager 1 - clone voyager
 COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 
-# BAD
-# RUN cd /aha && git clone ssh://git@github.com/StanfordAHA/voyager.git voyager && 
-# git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git
-# git clone https://github.com/StanfordAHA/voyager.git voyager && \
-#
-
-# also bad
 RUN cd /aha && \
-  printenv && \
-  echo GT=$GITHUB_TOKEN && \
   if [ "$BUILDKITE" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
   else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
   cd /aha/voyager && \
@@ -126,8 +113,6 @@ RUN cd /aha && \
   mv .git/ /aha/.git/modules/voyager/ && \
   ln -s /aha/.git/modules/voyager/ .git && \
   git checkout `cat /tmp/HEAD` && git submodule update --init --recursive
-
-
 
 # Pono
 WORKDIR /aha
@@ -287,6 +272,10 @@ RUN apt-get install -y libc6-dev-amd64
 RUN apt-get update && apt-get install -y linux-headers-generic
 
 RUN ln -s /usr/include/asm-generic/ /usr/include/asm
+
+# FIXME
+# Voyager 1 temporarily moved to beginning of file for debugging, see above
+# If we don't see git clone voyager errors before say, a month from now (Oct 16), can move it back maybe
 
 # Voyager 2 - setup voyager
 COPY ./voyager /aha/voyager

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,26 @@ RUN source bin/activate && \
   pip install matplotlib && \
   echo DONE
 
+# Put the problem child here up front so that it can fail quickly :(
+
+# Voyager 1 - clone voyager
+COPY ./.git/modules/voyager/HEAD /tmp/HEAD
+
+# BAD
+# RUN cd /aha && git clone ssh://git@github.com/StanfordAHA/voyager.git voyager && 
+
+# also bad
+RUN cd /aha && \
+  echo GT=$GITHUB_TOKEN | cut -b 1-20 && \
+  git clone https://github.com/StanfordAHA/voyager.git voyager && \
+  cd /aha/voyager && \
+  mkdir -p /aha/.git/modules && \
+  mv .git/ /aha/.git/modules/voyager/ && \
+  ln -s /aha/.git/modules/voyager/ .git && \
+  git checkout `cat /tmp/HEAD` && git submodule update --init --recursive
+
+
+
 # Pono
 WORKDIR /aha
 COPY ./pono /aha/pono
@@ -257,20 +277,6 @@ RUN apt-get install -y libc6-dev-amd64
 RUN apt-get update && apt-get install -y linux-headers-generic
 
 RUN ln -s /usr/include/asm-generic/ /usr/include/asm
-
-# Voyager 1 - clone voyager
-COPY ./.git/modules/voyager/HEAD /tmp/HEAD
-
-# BAD
-# RUN cd /aha && git clone https://github.com/StanfordAHA/voyager.git voyager
-
-# GOOD
-RUN cd /aha && git clone ssh://git@github.com/StanfordAHA/voyager.git voyager && \
-  cd /aha/voyager && \
-  mkdir -p /aha/.git/modules && \
-  mv .git/ /aha/.git/modules/voyager/ && \
-  ln -s /aha/.git/modules/voyager/ .git && \
-  git checkout `cat /tmp/HEAD` && git submodule update --init --recursive
 
 # Voyager 2 - setup voyager
 COPY ./voyager /aha/voyager

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,10 @@ LABEL description="garnet"
 ENV DEBIAN_FRONTEND=noninteractive
 ARG GITHUB_TOKEN
 
-ENV BUILDKITE
-ARG BUILDKITE
+# USE_HTTPS set by regress-metahooks.sh "docker build --build-arg USE_HTTPS=True"
+# It tells us to use http protocol for git clone voyager
+# FIXME I'm sure there are ten better ways to do this :(
+ARG USE_HTTPS
 
 RUN apt-get update && \
     apt-get install -y \
@@ -109,7 +111,7 @@ RUN source bin/activate && \
 COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 
 RUN cd /aha && \
-  if [ "$BUILDKITE" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
+  if [ "$USE_HTTPS" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
   else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
   cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ LABEL description="garnet"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG BAR
+
 RUN apt-get update && \
     apt-get install -y \
         build-essential software-properties-common && \
@@ -112,6 +114,7 @@ RUN cd /aha && \
   echo GT=$GITHUB_TOKEN | cut -b 1-20 && \
   echo HHT=$HUGGINGFACE_HUB_TOKEN | cut -b 1-20 && \
   echo FOO=$FOO && \
+  echo BAR=$BAR && \
   git clone https://github.com/StanfordAHA/voyager.git voyager && \
   cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,10 +110,13 @@ RUN source bin/activate && \
 # Voyager 1 - clone voyager
 COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 
+#   if [ "$USE_HTTPS" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
+#   else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
+
+
 RUN cd /aha && \
-  if [ "$USE_HTTPS" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
-  else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
   cd /aha/voyager && \
+  git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager && \
   mkdir -p /aha/.git/modules && \
   mv .git/ /aha/.git/modules/voyager/ && \
   ln -s /aha/.git/modules/voyager/ .git && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ LABEL description="garnet"
 ENV DEBIAN_FRONTEND=noninteractive
 ARG GITHUB_TOKEN
 
+ENV BUILDKITE
+ARG BUILDKITE
+
 RUN apt-get update && \
     apt-get install -y \
         build-essential software-properties-common && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -260,7 +260,12 @@ RUN ln -s /usr/include/asm-generic/ /usr/include/asm
 
 # Voyager 1 - clone voyager
 COPY ./.git/modules/voyager/HEAD /tmp/HEAD
-RUN cd /aha && git clone https://github.com/StanfordAHA/voyager.git voyager && \
+
+# BAD
+# RUN cd /aha && git clone https://github.com/StanfordAHA/voyager.git voyager
+
+# GOOD
+RUN cd /aha && git clone ssh://git@github.com/StanfordAHA/voyager.git voyager && \
   cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \
   mv .git/ /aha/.git/modules/voyager/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,8 +115,8 @@ COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 
 
 RUN cd /aha && \
-  cd /aha/voyager && \
   git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager && \
+  cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \
   mv .git/ /aha/.git/modules/voyager/ && \
   ln -s /aha/.git/modules/voyager/ .git && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM docker.io/ubuntu:20.04
 LABEL description="garnet"
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG GITHUB_TOKEN
+# ARG GITHUB_TOKEN
 
 # USE_HTTPS set by regress-metahooks.sh "docker build --build-arg USE_HTTPS=True"
 # It tells us to use http protocol for git clone voyager
@@ -113,11 +113,12 @@ COPY ./.git/modules/voyager/HEAD /tmp/HEAD
 #   if [ "$USE_HTTPS" ]; then git clone https://github.com/StanfordAHA/voyager.git voyager; \
 #   else git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager; fi && \
 #  git clone https://x-access-token:${GITHUB_TOKEN}@github.com:/StanfordAHA/voyager.git voyager && \
-
+# git clone ssh://git@github.com/StanfordAHA/voyager.git voyager
 
 # GIT_AUTH_TOKENS maybe
-RUN cd /aha && \
-  git clone https://github.com:/StanfordAHA/voyager.git voyager && \
+RUN --mount=type=secret,id=gtoken \
+  cd /aha && \
+  git clone https://$(cat /run/secrets/gtoken)@github.com:/StanfordAHA/voyager.git voyager && \
   cd /aha/voyager && \
   mkdir -p /aha/.git/modules && \
   mv .git/ /aha/.git/modules/voyager/ && \

--- a/aha/util/map.py
+++ b/aha/util/map.py
@@ -73,9 +73,10 @@ def load_environmental_vars(env, app, layer=None, env_parameters=None):
     if os.getenv("DENSE_READY_VALID") == "1":
         new_env_vars["PIPELINED"] = "0"
 
+    # No need for each var to have its own '---' group, just use '+++' instead of '---'
     print(f"--- Setting environment variables for {app}")
     for n, v in new_env_vars.items():
-        print(f"--- {n} = {v}")
+        print(f"... {n} = {v}")
         env[n] = v
 
 

--- a/aha/util/regress.py
+++ b/aha/util/regress.py
@@ -254,7 +254,7 @@ def test_sparse_app(testname, seed_flow, data_tile_pairs,
     if test == "":
         test = testname
 
-    print(f"--- {test}")
+    print(f"--- {test} - glb testing")
 
     env_vars = {"PYTHONPATH": "/aha/garnet/"}
     if using_matrix_unit:
@@ -273,7 +273,6 @@ def test_sparse_app(testname, seed_flow, data_tile_pairs,
     except:
         pass
 
-    print(f"--- {test} - glb testing")
     if(seed_flow):
         print("RUNNING SEED FLOW", flush=True)
         start = time.time()
@@ -470,7 +469,6 @@ def test_dense_app(
 
     # Note testname is for logging/display purposes only...!
     testname = f'{test_orig}/{layer}' if layer is not None else test_orig
-    print(f"--- {testname}", flush=True)
     print(f"--- {testname} - compiling and mapping", flush=True)
     app_path = "/aha/Halide-to-Hardware/apps/hardware_benchmarks/" + test
     voyager_collateral_path = "/aha/voyager/compiled_collateral"

--- a/aha/util/regress_tests/tests.py
+++ b/aha/util/regress_tests/tests.py
@@ -72,7 +72,6 @@ class Tests:
             external_mu_tests_fp = []
             hardcoded_dense_tests = []
 
-        # PR_AHA test suite for aha-repo push/pull, part 1/3
         elif testname == "pr_aha1":
 
             width, height = 28, 16
@@ -95,42 +94,47 @@ class Tests:
                 "tensor3_mttkrp",
                 "tensor3_ttv",
             ]
+            external_mu_tests_fp = [
+                 # K-DIM HOST TILING CONV5_X
+                "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel0_RV_E64_MB",
+                "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel1_RV_E64_MB",
+                "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel2_RV_E64_MB",
+                "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel3_RV_E64_MB",
+            ]
+        elif testname == "pr_aha2":
+            width, height = 28, 16
+            cols_removed, mu_oc_0 = 12, 32
+            external_mu_tests_fp = [
+                # 4935 sec (build 12187)
+                "resnet18-submodule_3 -> zircon_residual_relu_fp_post_conv2_x_RV_E64_MB",
+            ]
+        elif testname == "pr_aha3":
+            width, height = 28, 16
+            cols_removed, mu_oc_0 = 12, 32
+            external_mu_tests_fp = [
+                # 2527 sec (build 12187)
+                "resnet18-submodule_7 -> zircon_residual_relu_fp_post_conv3_x_RV_E64_MB",
+
+                # INNER REDUCTION WORKAROUND CONV4_X downsample
+                # 2454 sec (build 12187)
+                "resnet18-submodule_11 -> zircon_residual_relu_fp_post_conv4_x_inner_reduction_workaround_RV_E64_MB",
+            ]
+
+        elif testname == "pr_aha4":
+            width, height = 28, 16
+            cols_removed, mu_oc_0 = 12, 32
             glb_tests_RV = [
-                # pr_aha1
                 "tests/conv_2_1_RV",
                 "tests/fp_e8m0_quant_test_RV",
                 "apps/pointwise_RV",
                 "apps/pointwise_RV_E64",
                 "apps/pointwise_RV_E64_MB",
                 "apps/pointwise_custom_packing_RV_E64",
-            ]
-            glb_tests_fp_RV = [
-                # pr_aha1
-                "tests/fp_arith_RV",
-                "tests/fp_comp_RV",
-                "apps/relu_layer_fp_RV",
-                "apps/relu_layer_multiout_fp_RV",
-                "apps/avgpool_layer_fp_RV_E64",
-                "apps/mat_vec_mul_fp_RV",
-            ]
-            hardcoded_dense_tests = []
+                "apps/gaussian_RV",
+                "tests/bit8_packing_test_RV",
+                "tests/bit8_unpack_test_RV",
+                "tests/fp_get_shared_exp_test_RV",
 
-            # Tests below are non-zircon and won't run by default
-            glb_tests = [
-                "apps/pointwise",
-            ]
-            glb_tests_fp = [
-                # pr_aha1
-                "tests/fp_arith",
-                "tests/fp_comp",
-                "apps/matrix_multiplication_fp",
-                "apps/relu_layer_fp",
-            ]
-            resnet_tests = [
-                "conv5_x",
-            ]
-            resnet_tests_fp = [
-                # "conv2_x_fp" # not yet supported by zircon
             ]
             behavioral_mu_tests = [
                 "apps/pointwise_mu_io_RV_E64",
@@ -139,7 +143,57 @@ class Tests:
                 "apps/get_e8m0_scale_test_fp_RV_E64_MB",
                 "apps/get_apply_e8m0_scale_fp_RV",
             ]
+            hardcoded_dense_tests = [
+                "apps/unsharp_RV",
+            ]
+        elif testname == "pr_aha5":
+            width, height = 28, 16
+            cols_removed, mu_oc_0 = 12, 32
+            # For sparse tests, we cherry pick some representative tests to run
+            no_zircon_sparse_tests = [
+                "vec_elemmul",
+                "mat_vecmul_ij",
+                "mat_elemadd_leakyrelu_exp",
+                "matmul_ikj",
+                "tensor3_mttkrp",
+            ]
+            # Tests below are non-zircon and won't run by default
+            glb_tests = [
+                "apps/pointwise",
+                "apps/maxpooling",
+                "tests/bit8_packing_test",
+                "tests/bit8_unpack_test",
+                "tests/fp_get_shared_exp_test",
+                "tests/fp_e8m0_quant_test",
+                "apps/camera_pipeline_2x2",
+                "apps/gaussian",
+                "apps/harris_color",
+                "apps/unsharp",
+            ]
+            glb_tests_fp = [
+                "tests/fp_arith",
+                "tests/fp_comp",
+                "apps/matrix_multiplication_fp",
+                "apps/relu_layer_fp",
+                "apps/scalar_max_fp",
+                "apps/scalar_avg_fp",
+            ]
+        elif testname == "pr_aha6":
+            width, height = 28, 16
+            cols_removed, mu_oc_0 = 12, 32
+            resnet_tests = [
+                "conv1",
+                "conv2_x",
+                "conv5_x",
+            ]
+            resnet_tests_fp = [
+                # "conv2_x_fp" # not yet supported by zircon
+            ]
+        elif testname == "pr_aha7":
+            width, height = 28, 16
+            cols_removed, mu_oc_0 = 12, 32
             external_mu_tests = [
+                "resnet18-conv2d_mx_default_6 -> zircon_nop_post_conv3_x_RV_E64_MB",
                 "resnet18-conv2d_mx_default_11 -> zircon_nop_post_conv4_x_RV_E64_MB",
                 "fakeconv2d-conv2d_mx_default -> zircon_nop_post_fakeconv2d_RV_E64_MB",
 
@@ -147,64 +201,21 @@ class Tests:
                 "resnet18-conv2d_mx_default_16 -> zircon_nop_post_conv5_x_kernel0_RV_E64_MB",
                 "resnet18-conv2d_mx_default_16 -> zircon_nop_post_conv5_x_kernel1_RV_E64_MB",
             ]
-            external_mu_tests_fp = [
-                # K-DIM HOST TILING CONV5_X
-                "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel0_RV_E64_MB",
-                "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel1_RV_E64_MB",
-                "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel2_RV_E64_MB",
-                "resnet18-submodule_17 -> zircon_residual_relu_fp_post_conv5_x_kernel3_RV_E64_MB",
-            ]
-
-        # PR_AHA test suite for aha-repo push/pull, part 2/3
-
-        elif testname == "pr_aha2":
-
+        elif testname == "pr_aha8":
             width, height = 28, 16
             cols_removed, mu_oc_0 = 12, 32
-
-            glb_tests_RV = [
-                "apps/gaussian_RV",
-                "apps/pointwise_custom_packing_RV_E64",
-            ]
             glb_tests_fp_RV = [
+                "tests/fp_arith_RV",
+                "tests/fp_comp_RV",
+                "apps/relu_layer_fp_RV",
+                "apps/relu_layer_multiout_fp_RV",
+                "apps/avgpool_layer_fp_RV_E64",
+                "apps/mat_vec_mul_fp_RV",
                 "apps/scalar_reduction_fp_RV",
                 "apps/scalar_max_fp_RV",
                 "apps/layer_norm_pass2_fp_RV",
                 "apps/layer_norm_pass3_fp_RV",
                 "apps/scalar_avg_fp_RV",
-            ]
-            glb_tests = [
-                "apps/maxpooling",
-                "tests/bit8_packing_test",
-                "tests/bit8_unpack_test",
-                "tests/fp_get_shared_exp_test",
-                "tests/fp_e8m0_quant_test",
-            ]
-            glb_tests_fp = [
-                "apps/scalar_max_fp",
-            ]
-            resnet_tests = [
-                "conv2_x",
-            ]
-            external_mu_tests_fp = [
-                "resnet18-submodule_3 -> zircon_residual_relu_fp_post_conv2_x_RV_E64_MB",
-                "resnet18-submodule_7 -> zircon_residual_relu_fp_post_conv3_x_RV_E64_MB",
-
-                # # INNER REDUCTION WORKAROUND CONV4_X downsample
-                "resnet18-submodule_11 -> zircon_residual_relu_fp_post_conv4_x_inner_reduction_workaround_RV_E64_MB",
-            ]
-
-        # PR_AHA test suite for aha-repo push/pull, part 3/3
-        elif testname == "pr_aha3":
-            width, height = 28, 16
-            cols_removed, mu_oc_0 = 12, 32
-
-            glb_tests_RV = [
-                "tests/bit8_packing_test_RV",
-                "tests/bit8_unpack_test_RV",
-                "tests/fp_get_shared_exp_test_RV",
-            ]
-            glb_tests_fp_RV = [
                 "apps/stable_softmax_pass2_fp_RV",
                 "apps/stable_softmax_pass3_fp_RV",
                 "apps/vector_reduction_fp_RV",
@@ -216,41 +227,19 @@ class Tests:
                 "apps/rope_pass1_fp_RV",
                 "apps/rope_pass2_fp_RV",
             ]
-            hardcoded_dense_tests = [
-                "apps/unsharp_RV",
-            ]
-            glb_tests = [
-                "apps/camera_pipeline_2x2",
-                "apps/gaussian",
-                "apps/harris_color",
-                "apps/unsharp",
-            ]
-            glb_tests_fp = [
-                "apps/scalar_avg_fp",
-            ]
-            resnet_tests = [
-                "conv1",
-            ]
-            external_mu_tests = [
-                "resnet18-conv2d_mx_default_6 -> zircon_nop_post_conv3_x_RV_E64_MB",
-            ]
+
+        elif testname == "pr_aha9":
+            width, height = 28, 16
+            cols_removed, mu_oc_0 = 12, 32
             external_mu_tests_fp = [
                 # X-DIM HOST TILING CONV1 (im2col-based)
                 "resnet18-submodule -> zircon_dequantize_relu_fp_post_conv1_kernel0_RV_E64_MB",
                 "resnet18-submodule -> zircon_dequantize_relu_fp_post_conv1_kernel1_RV_E64_MB",
                 "resnet18-submodule -> zircon_dequantize_relu_fp_post_conv1_kernel2_RV_E64_MB",
                 "resnet18-submodule -> zircon_dequantize_relu_fp_post_conv1_kernel3_RV_E64_MB",
-
+ 
                 # INNER REDUCTION WORKAROUND CONV5_X downsample
                 "resnet18-submodule_15 -> zircon_residual_relu_fp_post_conv5_x_inner_reduction_workaround_RV_E64_MB",
-            ]
-            # For sparse tests, we cherry pick some representative tests to run
-            no_zircon_sparse_tests = [
-                "vec_elemmul",
-                "mat_vecmul_ij",
-                "mat_elemadd_leakyrelu_exp",
-                "matmul_ikj",
-                "tensor3_mttkrp",
             ]
 
         # PR_AHA test suite for aha-repo push/pull;
@@ -267,6 +256,12 @@ class Tests:
             pr_aha = Tests('pr_aha1').__dict__
             merge_tests(pr_aha, Tests('pr_aha2').__dict__)
             merge_tests(pr_aha, Tests('pr_aha3').__dict__)
+            merge_tests(pr_aha, Tests('pr_aha4').__dict__)
+            merge_tests(pr_aha, Tests('pr_aha5').__dict__)
+            merge_tests(pr_aha, Tests('pr_aha6').__dict__)
+            merge_tests(pr_aha, Tests('pr_aha7').__dict__)
+            merge_tests(pr_aha, Tests('pr_aha8').__dict__)
+            merge_tests(pr_aha, Tests('pr_aha9').__dict__)
             self.__dict__.update(pr_aha)
             # print(f"{self.resnet_tests=}", flush=True)
             return

--- a/aha/util/test.py
+++ b/aha/util/test.py
@@ -95,9 +95,10 @@ def load_environmental_vars(env, app, layer=None, env_parameters=None):
             else:
                 new_env_vars.update(env_vars_fin[app_name][str(env_parameters)])
 
+    # No need for each var to have its own '---' group, just use '+++' instead of '---'
     print(f"--- Setting environment variables for {app}")
     for n, v in new_env_vars.items():
-        print(f"--- {n} = {v}")
+        print(f"... {n} = {v}")
         env[n] = v
         os.environ[n] = v
 


### PR DESCRIPTION
Currently, per-check-in regressions run as three parallel jobs of 6-8 hours each, e.g. https://buildkite.com/stanford-aha/aha-flow/builds/12185

This new change breaks rhe regressions into *nine* chunks of 2-3 hours each, e.g. https://buildkite.com/stanford-aha/aha-flow/builds/12196.

This reduces overall regression time, and also reduces worst-case time lost for any one job failure.

A fairness algorithm ("CONCURRENCY=4" in `pipeline.yml`) prevents any one build from reserving all the buildkite agents at once, so that competing builds don't have to wait as long. I.e. any one build can have at most four long-running jubs in flight at any given time.

In addition, a slight update to `custom-check.sh` will hopefully fix recent problems with the `BUILDKITE_COMMIT` message displayed when an aha-flow build is launched from a pull request. You can see an example of this in build 12074, which is based on BUILD_COMMIT ed4a34fa, but which displays the incorrect BUILD_MESSAGE "oops lost the mdkey" from commit 95ee237

https://buildkite.com/stanford-aha/aha-flow/builds/12074

Finally, I did a slight tweak of log output for `aha/util/{map,regress,test}.py` in hopes of a slightly cleaner/simpler build log.

Oh, and also I lint-checked a couple of scripts with `shellcheck`, so you will see a lot of annoying little changes mostly to do with quote-marks, sorry!


